### PR TITLE
feat: 히스토리 페이지 및 모달 UI 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
-        "react-router-dom": "^7.11.0"
+        "react-router": "^7.11.0"
       },
       "devDependencies": {
         "@crxjs/vite-plugin": "^2.3.0",
@@ -4057,22 +4057,6 @@
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.11.0.tgz",
-      "integrity": "sha512-e49Ir/kMGRzFOOrYQBdoitq3ULigw4lKbAyKusnvtDu2t4dBX4AGYPrzNvorXmVuOyeakai6FUPW5MmibvVG8g==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.11.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/resolve-from": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.2.0",
-        "react-dom": "^19.2.0"
+        "react-dom": "^19.2.0",
+        "react-router-dom": "^7.11.0"
       },
       "devDependencies": {
         "@crxjs/vite-plugin": "^2.3.0",
@@ -2193,6 +2194,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4023,6 +4037,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.11.0.tgz",
+      "integrity": "sha512-uI4JkMmjbWCZc01WVP2cH7ZfSzH91JAZUDd7/nIprDgWxBV1TkkmLToFh7EbMTcMak8URFRa2YoBL/W8GWnCTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.11.0.tgz",
+      "integrity": "sha512-e49Ir/kMGRzFOOrYQBdoitq3ULigw4lKbAyKusnvtDu2t4dBX4AGYPrzNvorXmVuOyeakai6FUPW5MmibvVG8g==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.11.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -4166,6 +4218,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "react-router-dom": "^7.11.0"
   },
   "devDependencies": {
     "@crxjs/vite-plugin": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-router-dom": "^7.11.0"
+    "react-router": "^7.11.0"
   },
   "devDependencies": {
     "@crxjs/vite-plugin": "^2.3.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,18 +1,13 @@
-import { Route, Routes } from "react-router";
+import { Outlet } from "react-router";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
-import SummaryPage from "./pages/SummaryPage";
-import HistoryPage from "./pages/HistoryPage";
 
 const App = () => {
   return (
     <div className="flex flex-col h-screen gap-5 p-5">
       <Header />
       <main className="flex flex-col items-center justify-center gap-2 w-full h-full p-3 border border-sl-blue rounded-xl">
-        <Routes>
-          <Route path="/" element={<SummaryPage />} />
-          <Route path="/history" element={<HistoryPage />} />
-        </Routes>
+        <Outlet />
       </main>
       <Footer />
     </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,6 @@ import Header from "./components/Header";
 import Footer from "./components/Footer";
 import SummaryPage from "./pages/SummaryPage";
 import HistoryPage from "./pages/HistoryPage";
-import DeleteModal from "./components/DeleteModal";
 
 const App = () => {
   return (
@@ -14,7 +13,6 @@ const App = () => {
           <Route path="/" element={<SummaryPage />} />
           <Route path="/history" element={<HistoryPage />} />
         </Routes>
-        <DeleteModal />
       </main>
       <Footer />
     </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { Route, Routes } from "react-router-dom";
+import { Route, Routes } from "react-router";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 import SummaryPage from "./pages/SummaryPage";

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import Header from "./components/Header";
 import Footer from "./components/Footer";
 import SummaryPage from "./pages/SummaryPage";
 import HistoryPage from "./pages/HistoryPage";
+import DeleteModal from "./components/DeleteModal";
 
 const App = () => {
   return (
@@ -13,6 +14,7 @@ const App = () => {
           <Route path="/" element={<SummaryPage />} />
           <Route path="/history" element={<HistoryPage />} />
         </Routes>
+        <DeleteModal />
       </main>
       <Footer />
     </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { Route, Routes } from "react-router-dom";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 import SummaryPage from "./pages/SummaryPage";
+import HistoryPage from "./pages/HistoryPage";
 
 const App = () => {
   return (
@@ -10,6 +11,7 @@ const App = () => {
       <main className="flex flex-col items-center justify-center gap-2 w-full h-full p-3 border border-sl-blue rounded-xl">
         <Routes>
           <Route path="/" element={<SummaryPage />} />
+          <Route path="/history" element={<HistoryPage />} />
         </Routes>
       </main>
       <Footer />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,28 +1,16 @@
+import { Route, Routes } from "react-router-dom";
 import Header from "./components/Header";
-import LoadingSpinner from "./components/LoadingSpinner";
 import Footer from "./components/Footer";
+import SummaryPage from "./pages/SummaryPage";
 
 const App = () => {
   return (
     <div className="flex flex-col h-screen gap-5 p-5">
       <Header />
       <main className="flex flex-col items-center justify-center gap-2 w-full h-full p-3 border border-sl-blue rounded-xl">
-        <button
-          type="button"
-          className="flex items-center justify-center gap-2 w-full h-[30px] bg-sl-blue border rounded-2xl font-medium text-white"
-        >
-          <img src="/images/icons/spreadlove-summary-16.svg" alt="요약 아이콘" aria-hidden="true" />
-          <span>이 페이지 요약하기</span>
-        </button>
-        <LoadingSpinner message={"페이지를 요약중입니다..."} />
-        <div className="flex flex-col gap-4">
-          <p className="text-[32px]">네이버</p>
-          <p className="text-[24px]">
-            이 페이지는 검색을 중심으로 뉴스, 쇼핑, 콘텐츠로 빠르게 이동하게 해주는 국내 대표 포털의
-            시작 화면이다. 검색창을 통해 원하는 상품을 한번에 찾을 수 있다. 뉴스, 스포츠, 연예, 날씨
-            정보가 실시간으로 제공된다.
-          </p>
-        </div>
+        <Routes>
+          <Route path="/" element={<SummaryPage />} />
+        </Routes>
       </main>
       <Footer />
     </div>

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,8 +1,8 @@
-const Button = ({ children, bgColor, borderColor }) => {
+const Button = ({ children, bgColor, borderColor, textColor = "text-sl-black" }) => {
   return (
     <button
       type="button"
-      className={`w-[65px] h-[30px] ${bgColor} border ${borderColor} rounded-2xl font-medium`}
+      className={`w-[65px] h-[30px] ${bgColor} border ${borderColor} rounded-2xl font-medium ${textColor}`}
     >
       {children}
     </button>

--- a/src/components/DeleteModal.jsx
+++ b/src/components/DeleteModal.jsx
@@ -1,0 +1,25 @@
+import Button from "./Button";
+
+const DeleteModal = () => {
+  return (
+    <div className="fixed inset-0 z-10 flex items-end justify-center">
+      <div className="absolute inset-0 bg-sl-black/85"></div>
+      <div className="relative w-full m-3 p-6 bg-sl-white border-3 border-sl-blue rounded-2xl shadow-2xl">
+        <h2 className="mb-2 text-xl font-bold text-sl-black">기록 삭제</h2>
+        <p className="mb-6 text-base font-semibold text-sl-black">
+          이 채팅을 삭제하시겠습니까? 이 작업은 취소할 수 없습니다.
+        </p>
+        <div className="flex justify-end gap-3">
+          <Button bgColor="bg-sl-white" borderColor="border-sl-blue">
+            취소
+          </Button>
+          <Button bgColor="bg-sl-red" borderColor="border-sl-red" textColor="text-sl-white">
+            삭제
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DeleteModal;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,13 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { MemoryRouter } from "react-router-dom";
 import "./styles/globals.css";
 import App from "./App.jsx";
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
-    <App />
+    <MemoryRouter>
+      <App />
+    </MemoryRouter>
   </StrictMode>,
 );

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import "./styles/globals.css";
 import App from "./App.jsx";
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,13 +1,11 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { MemoryRouter } from "react-router";
+import { RouterProvider } from "react-router";
+import { router } from "./router";
 import "./styles/globals.css";
-import App from "./App.jsx";
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
-    <MemoryRouter>
-      <App />
-    </MemoryRouter>
+    <RouterProvider router={router} />
   </StrictMode>,
 );

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -1,3 +1,5 @@
+import DeleteModal from "../components/DeleteModal";
+
 const HistoryPage = () => {
   return (
     <>
@@ -33,6 +35,7 @@ const HistoryPage = () => {
           <a href="/">2026년 1월 3일 기록</a>
         </li>
       </ul>
+      <DeleteModal />
     </>
   );
 };

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -1,0 +1,46 @@
+const HistoryPage = () => {
+  return (
+    <>
+      <ul className="flex flex-col w-full gap-3">
+        <li className="flex w-full h-[40px] bg-sl-blue  justify-center items-center rounded-2xl text-sl-white text-base">
+          <a href="">2026년 1월 3일 기록</a>
+        </li>
+        <li className="flex w-full h-[40px] bg-sl-blue  justify-center items-center rounded-2xl text-sl-white text-base">
+          <a href="">2026년 1월 4일 기록</a>
+        </li>
+        <li className="flex w-full h-[40px] bg-sl-blue  justify-center items-center rounded-2xl text-sl-white text-base">
+          <a href="">2026년 1월 5일 기록</a>
+        </li>
+        <li className="flex w-full h-[40px] bg-sl-blue  justify-center items-center rounded-2xl text-sl-white text-base">
+          <a href="">2026년 1월 5일 기록</a>
+        </li>
+        <li className="flex w-full h-[40px] bg-sl-blue  justify-center items-center rounded-2xl text-sl-white text-base">
+          <a href="">2026년 1월 5일 기록</a>
+        </li>
+        <li className="flex w-full h-[40px] bg-sl-blue  justify-center items-center rounded-2xl text-sl-white text-base">
+          <a href="">2026년 1월 5일 기록</a>
+        </li>
+        <li className="flex w-full h-[40px] bg-sl-blue  justify-center items-center rounded-2xl text-sl-white text-base">
+          <a href="">2026년 1월 5일 기록</a>
+        </li>
+        <li className="flex w-full h-[40px] bg-sl-blue  justify-center items-center rounded-2xl text-sl-white text-base">
+          <a href="">2026년 1월 5일 기록</a>
+        </li>
+        <li className="flex w-full h-[40px] bg-sl-blue  justify-center items-center rounded-2xl text-sl-white text-base">
+          <a href="">2026년 1월 5일 기록</a>
+        </li>
+        <li className="flex w-full h-[40px] bg-sl-blue  justify-center items-center rounded-2xl text-sl-white text-base">
+          <a href="">2026년 1월 5일 기록</a>
+        </li>
+        <li className="flex w-full h-[40px] bg-sl-blue  justify-center items-center rounded-2xl text-sl-white text-base">
+          <a href="">2026년 1월 5일 기록</a>
+        </li>
+        <li className="flex w-full h-[40px] bg-sl-blue  justify-center items-center rounded-2xl text-sl-white text-base">
+          <a href="">2026년 1월 5일 기록</a>
+        </li>
+      </ul>
+    </>
+  );
+};
+
+export default HistoryPage;

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -2,41 +2,35 @@ const HistoryPage = () => {
   return (
     <>
       <ul className="flex flex-col w-full gap-3">
-        <li className="flex w-full h-[40px] bg-sl-blue  justify-center items-center rounded-2xl text-sl-white text-base">
-          <a href="">2026년 1월 3일 기록</a>
+        <li className="flex justify-center items-center w-full h-10 bg-sl-blue rounded-2xl text-base text-sl-white">
+          <a href="/">2026년 1월 3일 기록</a>
         </li>
-        <li className="flex w-full h-[40px] bg-sl-blue  justify-center items-center rounded-2xl text-sl-white text-base">
-          <a href="">2026년 1월 4일 기록</a>
+        <li className="flex justify-center items-center w-full h-10 bg-sl-blue rounded-2xl text-base text-sl-white">
+          <a href="/">2026년 1월 3일 기록</a>
         </li>
-        <li className="flex w-full h-[40px] bg-sl-blue  justify-center items-center rounded-2xl text-sl-white text-base">
-          <a href="">2026년 1월 5일 기록</a>
+        <li className="flex justify-center items-center w-full h-10 bg-sl-blue rounded-2xl text-base text-sl-white">
+          <a href="/">2026년 1월 3일 기록</a>
         </li>
-        <li className="flex w-full h-[40px] bg-sl-blue  justify-center items-center rounded-2xl text-sl-white text-base">
-          <a href="">2026년 1월 5일 기록</a>
+        <li className="flex justify-center items-center w-full h-10 bg-sl-blue rounded-2xl text-base text-sl-white">
+          <a href="/">2026년 1월 3일 기록</a>
         </li>
-        <li className="flex w-full h-[40px] bg-sl-blue  justify-center items-center rounded-2xl text-sl-white text-base">
-          <a href="">2026년 1월 5일 기록</a>
+        <li className="flex justify-center items-center w-full h-10 bg-sl-blue rounded-2xl text-base text-sl-white">
+          <a href="/">2026년 1월 3일 기록</a>
         </li>
-        <li className="flex w-full h-[40px] bg-sl-blue  justify-center items-center rounded-2xl text-sl-white text-base">
-          <a href="">2026년 1월 5일 기록</a>
+        <li className="flex justify-center items-center w-full h-10 bg-sl-blue rounded-2xl text-base text-sl-white">
+          <a href="/">2026년 1월 3일 기록</a>
         </li>
-        <li className="flex w-full h-[40px] bg-sl-blue  justify-center items-center rounded-2xl text-sl-white text-base">
-          <a href="">2026년 1월 5일 기록</a>
+        <li className="flex justify-center items-center w-full h-10 bg-sl-blue rounded-2xl text-base text-sl-white">
+          <a href="/">2026년 1월 3일 기록</a>
         </li>
-        <li className="flex w-full h-[40px] bg-sl-blue  justify-center items-center rounded-2xl text-sl-white text-base">
-          <a href="">2026년 1월 5일 기록</a>
+        <li className="flex justify-center items-center w-full h-10 bg-sl-blue rounded-2xl text-base text-sl-white">
+          <a href="/">2026년 1월 3일 기록</a>
         </li>
-        <li className="flex w-full h-[40px] bg-sl-blue  justify-center items-center rounded-2xl text-sl-white text-base">
-          <a href="">2026년 1월 5일 기록</a>
+        <li className="flex justify-center items-center w-full h-10 bg-sl-blue rounded-2xl text-base text-sl-white">
+          <a href="/">2026년 1월 3일 기록</a>
         </li>
-        <li className="flex w-full h-[40px] bg-sl-blue  justify-center items-center rounded-2xl text-sl-white text-base">
-          <a href="">2026년 1월 5일 기록</a>
-        </li>
-        <li className="flex w-full h-[40px] bg-sl-blue  justify-center items-center rounded-2xl text-sl-white text-base">
-          <a href="">2026년 1월 5일 기록</a>
-        </li>
-        <li className="flex w-full h-[40px] bg-sl-blue  justify-center items-center rounded-2xl text-sl-white text-base">
-          <a href="">2026년 1월 5일 기록</a>
+        <li className="flex justify-center items-center w-full h-10 bg-sl-blue rounded-2xl text-base text-sl-white">
+          <a href="/">2026년 1월 3일 기록</a>
         </li>
       </ul>
     </>

--- a/src/pages/SummaryPage.jsx
+++ b/src/pages/SummaryPage.jsx
@@ -1,0 +1,25 @@
+import LoadingSpinner from "../components/LoadingSpinner";
+
+const SummaryPage = () => {
+  return (
+    <>
+      <button
+        type="button"
+        className="flex items-center justify-center gap-2 w-full h-[30px] bg-sl-blue border rounded-2xl font-medium text-white"
+      >
+        <img src="/images/icons/spreadlove-summary-16.svg" alt="요약 아이콘" aria-hidden="true" />
+        <span>이 페이지 요약하기</span>
+      </button>
+      <LoadingSpinner message={"페이지를 요약중입니다..."} />
+      <div className="flex flex-col gap-4">
+        <p className="text-[32px]">네이버</p>
+        <p className="text-2xl">
+          이 페이지는 검색을 중심으로 뉴스, 쇼핑, 콘텐츠로 빠르게 이동하게 해주는 국내 대표 포털의
+          시작 화면이다. 검색창을 통해 원하는 상품을 한번에 찾을 수 있다. 뉴스, 스포츠, 연예, 날씨
+          정보가 실시간으로 제공된다.
+        </p>
+      </div>
+    </>
+  );
+};
+export default SummaryPage;

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -1,0 +1,15 @@
+import { createMemoryRouter } from "react-router";
+import App from "./App";
+import SummaryPage from "./pages/SummaryPage";
+import HistoryPage from "./pages/HistoryPage";
+
+export const router = createMemoryRouter([
+  {
+    path: "/",
+    element: <App />,
+    children: [
+      { index: true, element: <SummaryPage /> },
+      { path: "history", element: <HistoryPage /> },
+    ],
+  },
+]);

--- a/src/router/index.jsx
+++ b/src/router/index.jsx
@@ -1,7 +1,7 @@
 import { createMemoryRouter } from "react-router";
-import App from "./App";
-import SummaryPage from "./pages/SummaryPage";
-import HistoryPage from "./pages/HistoryPage";
+import App from "../App";
+import SummaryPage from "../pages/SummaryPage";
+import HistoryPage from "../pages/HistoryPage";
 
 export const router = createMemoryRouter([
   {


### PR DESCRIPTION
## 변경 내용
> #3
- [x] react-router-dom 라이브러리 추가
- [x] MemoryRouter 기반 라우팅 구조로 수정
- [x] SummaryPage 컴포넌트 분리
- [x] HistoryPage 추가 및 라우팅 연결
- [x] DeleteModal 컴포넌트 추가
- [x] Button 컴포넌트에 textColor prop 추가

## 기타 참고 사항

### 히스토리 페이지 UI
<img width="320" height="540" alt="image" src="https://github.com/user-attachments/assets/77963fcc-d785-4452-b068-4a76a4639c81" />

### 모달창 UI
<img width="320" height="540" alt="image" src="https://github.com/user-attachments/assets/7f33a7f3-b976-4e1b-8494-41a03fe1cc27" />

### 스크린 리더 접근성
접근성을 위해 `<ul>`과 `<li>` 태그로 히스토리 페이지를 구현했습니다. 모달창의 경우 스크린 리더와의 기본 호환성은 확인했으나, 실제로는 삭제 버튼 클릭 시 동적으로 표시되어야 하므로 현재 단계에서는 추가적인 접근성 테스트가 어렵다고 판단하여 ARIA속성을 추가하지 않았습니다.
그래서 동적 기능 구현 후 실제로 테스트를 해보면서 필요한 ARIA 속성을 추가할 예정입니다.

### react-router-dom 도입 이유
지난 PR에서 다뤘던 작업들은 상태 기반 분기로도 해결할 수 있다고 생각했었지만, 메인(요약) 페이지와 기록 페이지 간 전환이 필요해 react-router-dom 추가했습니다.

#### ‼️ react-router로 수정했습니다
PR을 작성하기 위해 조사를 하던 중 React Router v7부터 `react-router-dom`의 모든 웹 관련 기능이 `react-router`로 통합되었다는 사실을 뒤늦게 발견했습니다..
공식 문서에서 react-router를 사용을 권장하기 때문에 수정했습니다. 
패키지가 통합되고 API가 동일하여 기능의 차이는 없으나 앞으로는 라이브러리를 도입 하기 전에 충분히 조사하겠습니다.

### MemoryRouter 선택 이유
익스텐션 환경에서는 브라우저 주소창을 사용할 수 없기 때문 BrowserRouter 대신 MemoryRouter를 사용했습니다. MemoryRouter는 메모리 히스토리를 통해 URL 없이도 페이지 간 전환과 뒤로가기 및 앞으로가기 네비게이션을 지원하기 때문에 라우팅 구조로 사용할 수 있다고 판단하여 선택했습니다.

#### 참고 문서
https://v5.reactrouter.com/web/api/MemoryRouter
브라우저가 아닌 환경에서 유용하다고 함

### Declarative모드에서 Data 모드로 전환이유
처음에 적용했던 방식은 Declarative 모드였는데 React Router v7에서 Remix와 통합되면서 Data 모드가 공식 권장 패턴이 되었습니다. 익숙한 패턴 대신 최신 패턴을 사용하면 좋겠다고 생각했고 백엔드와 연동할 때 loader 기능이 편리하다고 해서 이참에 익혀보고자 적용했습니다.

#### 참고 사이트
https://www.heropy.dev/p/9tesDt

### MemoryRouter -> createMemoryRouter
변경한 이유는 Data모드에서 자주 사용되고 createMemoryRouter는 loader라는 기능이 있는데 추후 서버와 연동을 했을 때 useEffect 없이 loader로 데이터를 미리 로드 할 수 있다고 해서입니다
