### PR TITLE
feat: 히스토리 전체 목록 조회

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,7 +6,7 @@ const App = () => {
   return (
     <div className="flex flex-col h-screen gap-5 p-5">
       <Header />
-      <main className="flex flex-col items-center justify-center gap-2 w-full h-full p-3 border border-sl-blue rounded-xl">
+      <main className="flex flex-col items-center gap-2 w-full h-full p-3 border border-sl-blue rounded-xl overflow-y-auto">
         <Outlet />
       </main>
       <Footer />

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -21,10 +21,23 @@ const handleSummarizeMessage = async (payload, sendResponse) => {
   }
 };
 
+const handleFetchHistories = async (sendResponse) => {
+  try {
+    const data = await api.get("histories").json();
+    sendResponse(data);
+  } catch (error) {
+    sendResponse({ success: false, error: error.message });
+  }
+};
+
 const messageHandler = (message, sender, sendResponse) => {
   if (message.type === "SUMMARIZE") {
     handleSummarizeMessage(message.payload, sendResponse);
+    return true;
+  }
 
+  if (message.type === "FETCH_HISTORIES") {
+    handleFetchHistories(sendResponse);
     return true;
   }
 };

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -24,13 +24,14 @@ const handleSummarizeMessage = async (payload, sendResponse) => {
 const handleFetchHistories = async (sendResponse) => {
   try {
     const data = await api.get("histories").json();
+
     sendResponse(data);
   } catch (error) {
     sendResponse({ success: false, error: error.message });
   }
 };
 
-const messageHandler = (message, sender, sendResponse) => {
+const handleMessage = (message, sender, sendResponse) => {
   if (message.type === "SUMMARIZE") {
     handleSummarizeMessage(message.payload, sendResponse);
     return true;
@@ -44,7 +45,7 @@ const messageHandler = (message, sender, sendResponse) => {
 
 const init = () => {
   chrome.sidePanel.setPanelBehavior(sidePanelConfig).catch((error) => console.error(error));
-  chrome.runtime.onMessage.addListener(messageHandler);
+  chrome.runtime.onMessage.addListener(handleMessage);
 };
 
 init();

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,9 +1,14 @@
-const Button = ({ children, bgColor, borderColor, textColor = "text-sl-black" }) => {
-  return (
-    <button
-      type="button"
-      className={`w-[65px] h-[30px] ${bgColor} border ${borderColor} rounded-2xl font-medium ${textColor}`}
-    >
+import { Link } from "react-router";
+
+const Button = ({ children, bgColor, borderColor, textColor = "text-sl-black", to }) => {
+  const className = `w-[65px] h-[30px] ${bgColor} border ${borderColor} rounded-2xl font-medium ${textColor}`;
+
+  return to ? (
+    <Link to={to} className={className}>
+      {children}
+    </Link>
+  ) : (
+    <button type="button" className={className}>
       {children}
     </button>
   );

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router";
 
 const Button = ({ children, bgColor, borderColor, textColor = "text-sl-black", to }) => {
-  const className = `w-[65px] h-[30px] ${bgColor} border ${borderColor} rounded-2xl font-medium ${textColor}`;
+  const className = `flex justify-center items-center w-[65px] h-[30px] ${bgColor} border ${borderColor} rounded-2xl font-medium ${textColor}`;
 
   return to ? (
     <Link to={to} className={className}>

--- a/src/components/EmptyState.jsx
+++ b/src/components/EmptyState.jsx
@@ -1,0 +1,9 @@
+const EmptyState = ({ message }) => {
+  return (
+    <div className="flex justify-center items-center w-full h-full" role="status">
+      <p className="text-sl-gray-dark text-lg">{message}</p>
+    </div>
+  );
+};
+
+export default EmptyState;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router";
 import Logo from "./Logo";
 import Button from "./Button";
 
@@ -7,9 +8,11 @@ const Header = () => {
       <div className="flex justify-between">
         <Logo iconSize={32} textSize={16} spacing="mt-0.5 ml-1" />
         <div className="flex gap-x-2">
-          <Button bgColor="bg-sl-white" borderColor="border-sl-blue">
-            기록
-          </Button>
+          <Link to="/history">
+            <Button bgColor="bg-sl-white" borderColor="border-sl-blue">
+              기록
+            </Button>
+          </Link>
           <Button bgColor="bg-sl-white" borderColor="border-sl-blue">
             로그인
           </Button>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router";
 import Logo from "./Logo";
 import Button from "./Button";
 
@@ -8,11 +7,9 @@ const Header = () => {
       <div className="flex justify-between">
         <Logo iconSize={32} textSize={16} spacing="mt-0.5 ml-1" />
         <div className="flex gap-x-2">
-          <Link to="/history">
-            <Button bgColor="bg-sl-white" borderColor="border-sl-blue">
-              기록
-            </Button>
-          </Link>
+          <Button to="/history" bgColor="bg-sl-white" borderColor="border-sl-blue">
+            기록
+          </Button>
           <Button bgColor="bg-sl-white" borderColor="border-sl-blue">
             로그인
           </Button>

--- a/src/components/NoData.jsx
+++ b/src/components/NoData.jsx
@@ -1,4 +1,4 @@
-const EmptyState = ({ message }) => {
+const NoData = ({ message }) => {
   return (
     <div className="flex justify-center items-center w-full h-full" role="status">
       <p className="text-sl-gray-dark text-lg">{message}</p>
@@ -6,4 +6,4 @@ const EmptyState = ({ message }) => {
   );
 };
 
-export default EmptyState;
+export default NoData;

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import EmptyState from "../components/EmptyState";
+import NoData from "../components/NoData";
 import LoadingSpinner from "../components/LoadingSpinner";
 
 const HistoryPage = () => {
@@ -32,7 +32,7 @@ const HistoryPage = () => {
   }
 
   if (histories.length === 0) {
-    return <EmptyState message={"기록이 없습니다"} />;
+    return <NoData message={"기록이 없습니다"} />;
   }
 
   return (

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -1,14 +1,19 @@
 import { useState, useEffect } from "react";
+import LoadingSpinner from "../components/LoadingSpinner";
 
 const HistoryPage = () => {
   const [histories, setHistories] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     let isMounted = true;
 
     chrome.runtime.sendMessage({ type: "FETCH_HISTORIES" }, (response) => {
-      if (isMounted && response?.success) {
-        setHistories(response.data.histories);
+      if (isMounted) {
+        if (response?.success) {
+          setHistories(response.data.histories);
+        }
+        setIsLoading(false);
       }
     });
 
@@ -16,6 +21,14 @@ const HistoryPage = () => {
       isMounted = false;
     };
   }, []);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center w-full h-full">
+        <LoadingSpinner message={"히스토리를 불러오는 중입니다..."} />
+      </div>
+    );
+  }
 
   return (
     <ul className="flex flex-col w-full gap-3">

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import EmptyState from "../components/EmptyState";
 import LoadingSpinner from "../components/LoadingSpinner";
 
 const HistoryPage = () => {
@@ -28,6 +29,10 @@ const HistoryPage = () => {
         <LoadingSpinner message={"히스토리를 불러오는 중입니다..."} />
       </div>
     );
+  }
+
+  if (histories.length === 0) {
+    return <EmptyState message={"기록이 없습니다"} />;
   }
 
   return (

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -10,12 +10,12 @@ const HistoryPage = () => {
     let isMounted = true;
 
     chrome.runtime.sendMessage({ type: "FETCH_HISTORIES" }, (response) => {
-      if (isMounted) {
-        if (response?.success) {
-          setHistories(response.data.histories);
-        }
-        setIsLoading(false);
+      if (!isMounted) return;
+
+      if (response?.success) {
+        setHistories(response.data.histories);
       }
+      setIsLoading(false);
     });
 
     return () => {

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -1,42 +1,38 @@
-import DeleteModal from "../components/DeleteModal";
+import { useState, useEffect } from "react";
 
 const HistoryPage = () => {
+  const [histories, setHistories] = useState([]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    chrome.runtime.sendMessage({ type: "FETCH_HISTORIES" }, (response) => {
+      if (isMounted && response?.success) {
+        setHistories(response.data.histories);
+      }
+    });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
   return (
-    <>
-      <ul className="flex flex-col w-full gap-3">
-        <li className="flex justify-center items-center w-full h-10 bg-sl-blue rounded-2xl text-base text-sl-white">
-          <a href="/">2026년 1월 3일 기록</a>
+    <ul className="flex flex-col w-full gap-3">
+      {histories.map((history) => (
+        <li
+          key={history.id}
+          className="flex justify-center items-center w-full h-10 bg-sl-blue rounded-2xl text-base text-sl-white"
+        >
+          {new Date(history.createdAt).toLocaleDateString("ko-KR", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+          })}{" "}
+          - {history.contents.title}
         </li>
-        <li className="flex justify-center items-center w-full h-10 bg-sl-blue rounded-2xl text-base text-sl-white">
-          <a href="/">2026년 1월 3일 기록</a>
-        </li>
-        <li className="flex justify-center items-center w-full h-10 bg-sl-blue rounded-2xl text-base text-sl-white">
-          <a href="/">2026년 1월 3일 기록</a>
-        </li>
-        <li className="flex justify-center items-center w-full h-10 bg-sl-blue rounded-2xl text-base text-sl-white">
-          <a href="/">2026년 1월 3일 기록</a>
-        </li>
-        <li className="flex justify-center items-center w-full h-10 bg-sl-blue rounded-2xl text-base text-sl-white">
-          <a href="/">2026년 1월 3일 기록</a>
-        </li>
-        <li className="flex justify-center items-center w-full h-10 bg-sl-blue rounded-2xl text-base text-sl-white">
-          <a href="/">2026년 1월 3일 기록</a>
-        </li>
-        <li className="flex justify-center items-center w-full h-10 bg-sl-blue rounded-2xl text-base text-sl-white">
-          <a href="/">2026년 1월 3일 기록</a>
-        </li>
-        <li className="flex justify-center items-center w-full h-10 bg-sl-blue rounded-2xl text-base text-sl-white">
-          <a href="/">2026년 1월 3일 기록</a>
-        </li>
-        <li className="flex justify-center items-center w-full h-10 bg-sl-blue rounded-2xl text-base text-sl-white">
-          <a href="/">2026년 1월 3일 기록</a>
-        </li>
-        <li className="flex justify-center items-center w-full h-10 bg-sl-blue rounded-2xl text-base text-sl-white">
-          <a href="/">2026년 1월 3일 기록</a>
-        </li>
-      </ul>
-      <DeleteModal />
-    </>
+      ))}
+    </ul>
   );
 };
 

--- a/src/pages/SummaryPage.jsx
+++ b/src/pages/SummaryPage.jsx
@@ -43,7 +43,7 @@ const SummaryPage = () => {
     );
   };
   return (
-    <>
+    <div className="flex flex-col items-center justify-center w-full h-full">
       {status === SUMMARY_STATUS.DEFAULT && (
         <button
           type="button"
@@ -61,7 +61,7 @@ const SummaryPage = () => {
           <p className="text-2xl">{summaryData.summary}</p>
         </div>
       )}
-    </>
+    </div>
   );
 };
 export default SummaryPage;


### PR DESCRIPTION
## 변경 내용:
> #12 

- [x] 기록 버튼 클릭 시 히스토리 페이지로 라우팅하고, 페이지 진입 시 히스토리 목록을 자동 조회하도록 구현
- [x] FETCH_HISTORIES 메시지를 통한 background ↔ popup 통신 및 백엔드 API 연동
- [x] API 요청 중 로딩 상태를 표시하여 빈 화면 깜빡임 및 무한 로딩 문제 방지
- [x] 로딩 중 사용자에게 안내 메시지 노출 ("히스토리를 불러오는 중입니다...")
- [x] 히스토리 데이터가 없을 경우 Empty State UI 표시
- [x] 재사용 가능한 EmptyState 컴포넌트 추가 및 접근성 고려 (`role="status"`)
- [x] 히스토리 날짜를 한국어 형식으로 포맷하여 가독성 개선
- [x] 히스토리 목록이 많을 때 상단이 잘리던 레이아웃 문제 수정 및 스크롤 동작 개선

## 기타 참고 사항:
### 1. 구현 흐름 요약

Chrome Extension Message Passing + `useEffect` 패턴
```
Link 클릭
 → 페이지 이동
 → useEffect 실행
 → chrome.runtime.sendMessage
 → background.js
 → 백엔드 API 호출
 → 응답 수신
 → setState
 → 화면 렌더링
```
### 2. 기술적 결정 사항
- Link + useEffect 패턴 선택
  - Header에서 데이터를 fetch한 뒤 이동하지 않고
  - 페이지 이동 후 HistoryPage에서 데이터를 요청하는 구조 선택
  - 선택 이유: 버튼 클릭 시 즉시 화면 전환 → 자연스러운 UX
  - 일반적인 웹 애플리케이션 데이터 패턴과 일치
  - 새로고침 시에도 데이터 재요청 가능
  
- 콜백 방식 유지
  - Chrome Extension 공식 문서 및 기존 코드(SummaryPage.jsx)와 일관성 유지
  - 추후 async / await 기반으로 리팩토링 가능

- TanStack Query 미사용 이유
  - 본 구조에서는 직접 API 호출하지 않음
  - 모든 API 요청은 background.js를 통해 수행
  - Message Passing 구조에서는 TanStack Query의 캐싱 / 상태 관리 이점이 제한적
  - 결론: MVP 단계에서는 기존 패턴과의 일관성이 더 중요
  - 필요 시 sendMessage를 queryFunction 내부에서 호출하는 방식으로 도입 가능

- MVP 구현의 제약 사항
  - 현재 구현에서는 다음 두 경우를 구분하지 않습니다.
      - API 성공 + 실제 데이터 없음
      - API 실패
      - 두 경우 모두: `histories.length === 0`
  - 선택이유
    - MVP 단계에서 개발 속도 우선
    - Chrome Extension 환경에서 API 실패 가능성 낮음
    - 무한 로딩이라는 치명적인 UX 문제를 우선적으로 해결

### 3. 추후 리팩토링 대상
- 에러 상태 분리 (error state 추가)
- API 실패 시 명확한 에러 메시지 표시
- "다시 시도" 버튼 추가
- 콜백 → async / await 리팩토링
- useQuery 도입을 통한 캐싱 및 상태 관리 자동화
- Router Loader 기반 데이터 패칭 구조 검토