### PR TITLE
feat: 히스토리 상세 페이지 조회

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -8,7 +8,6 @@ const handleSummarizeMessage = async (payload, sendResponse) => {
   const imageBlob = await response.blob();
 
   const formData = new FormData();
-
   formData.append("url", url);
   formData.append("image", imageBlob, "screenshot.png");
 
@@ -31,6 +30,16 @@ const handleFetchHistories = async (sendResponse) => {
   }
 };
 
+const handleFetchHistoryDetail = async (payload, sendResponse) => {
+  try {
+    const data = await api.get(`histories/${payload.historyId}`).json();
+
+    sendResponse(data);
+  } catch (error) {
+    sendResponse({ success: false, error: error.message });
+  }
+};
+
 const handleMessage = (message, sender, sendResponse) => {
   if (message.type === "SUMMARIZE") {
     handleSummarizeMessage(message.payload, sendResponse);
@@ -39,6 +48,11 @@ const handleMessage = (message, sender, sendResponse) => {
 
   if (message.type === "FETCH_HISTORIES") {
     handleFetchHistories(sendResponse);
+    return true;
+  }
+
+  if (message.type === "FETCH_HISTORY_DETAIL") {
+    handleFetchHistoryDetail(message.payload, sendResponse);
     return true;
   }
 };

--- a/src/pages/HistoryDetailPage.jsx
+++ b/src/pages/HistoryDetailPage.jsx
@@ -1,0 +1,10 @@
+const HistoryDetailPage = () => {
+  return (
+    <div className="flex flex-col items-center justify-center w-full h-full">
+      <h1 className="text-[32px]">히스토리 상세 페이지</h1>
+      <p>여기에 상세 정보가 표시됩니다.</p>
+    </div>
+  );
+};
+
+export default HistoryDetailPage;

--- a/src/pages/HistoryDetailPage.jsx
+++ b/src/pages/HistoryDetailPage.jsx
@@ -1,8 +1,71 @@
+import { useState, useEffect } from "react";
+import { useParams, Link } from "react-router";
+import LoadingSpinner from "../components/LoadingSpinner";
+
 const HistoryDetailPage = () => {
+  const { id } = useParams();
+  const [history, setHistory] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    chrome.runtime.sendMessage(
+      { type: "FETCH_HISTORY_DETAIL", payload: { historyId: id } },
+      (response) => {
+        if (isMounted) {
+          if (response?.success) {
+            setHistory(response.data);
+          }
+          setIsLoading(false);
+        }
+      },
+    );
+
+    return () => {
+      isMounted = false;
+    };
+  }, [id]);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center w-full h-full">
+        <LoadingSpinner message={"상세 정보를 불러오는 중입니다..."} />
+      </div>
+    );
+  }
+
+  if (!history) {
+    return (
+      <div className="flex flex-col items-center justify-center w-full h-full gap-4">
+        <p className="text-sl-gray-dark text-lg">기록을 찾을 수 없습니다</p>
+        <Link to="/history" className="text-sl-blue underline">
+          목록으로
+        </Link>
+      </div>
+    );
+  }
+
   return (
-    <div className="flex flex-col items-center justify-center w-full h-full">
-      <h1 className="text-[32px]">히스토리 상세 페이지</h1>
-      <p>여기에 상세 정보가 표시됩니다.</p>
+    <div className="flex flex-col w-full h-full">
+      <div className="flex flex-col flex-1 gap-4 overflow-y-auto">
+        <h1 className="text-[32px]">{history.contents.title}</h1>
+        <p className="text-sl-gray-dark text-sm">
+          요약 날짜:{" "}
+          {new Date(history.createdAt).toLocaleDateString("ko-KR", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+          })}
+        </p>
+        <p className="text-lg">{history.contents.summary}</p>
+      </div>
+      <Link
+        to="/history"
+        className="flex justify-center items-center w-full h-10 mt-4 bg-sl-blue rounded-2xl text-base text-sl-white"
+      >
+        목록으로
+      </Link>
     </div>
   );
 };

--- a/src/pages/HistoryDetailPage.jsx
+++ b/src/pages/HistoryDetailPage.jsx
@@ -13,12 +13,12 @@ const HistoryDetailPage = () => {
     chrome.runtime.sendMessage(
       { type: "FETCH_HISTORY_DETAIL", payload: { historyId: id } },
       (response) => {
-        if (isMounted) {
-          if (response?.success) {
-            setHistory(response.data);
-          }
-          setIsLoading(false);
+        if (!isMounted) return;
+
+        if (response?.success) {
+          setHistory(response.data);
         }
+        setIsLoading(false);
       },
     );
 

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -39,16 +39,19 @@ const HistoryPage = () => {
   return (
     <ul className="flex flex-col w-full gap-3">
       {histories.map((history) => (
-        <Link key={history.id} to={`/history/${history.id}`}>
-          <li className="w-full h-10 px-4 bg-sl-blue rounded-2xl text-base text-sl-white truncate leading-10 text-center">
+        <li key={history.id}>
+          <Link
+            to={`/history/${history.id}`}
+            className="block w-full h-10 px-4 bg-sl-blue rounded-2xl text-base text-sl-white truncate leading-10 text-center"
+          >
             {new Date(history.createdAt).toLocaleDateString("ko-KR", {
               year: "numeric",
               month: "long",
               day: "numeric",
             })}{" "}
             - {history.contents.title}
-          </li>
-        </Link>
+          </Link>
+        </li>
       ))}
     </ul>
   );

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { Link } from "react-router";
 import NoData from "../components/NoData";
 import LoadingSpinner from "../components/LoadingSpinner";
 
@@ -26,7 +27,7 @@ const HistoryPage = () => {
   if (isLoading) {
     return (
       <div className="flex justify-center items-center w-full h-full">
-        <LoadingSpinner message={"히스토리를 불러오는 중입니다..."} />
+        <LoadingSpinner message={"전체 목록을 불러오는 중입니다..."} />
       </div>
     );
   }
@@ -38,17 +39,16 @@ const HistoryPage = () => {
   return (
     <ul className="flex flex-col w-full gap-3">
       {histories.map((history) => (
-        <li
-          key={history.id}
-          className="flex justify-center items-center w-full h-10 bg-sl-blue rounded-2xl text-base text-sl-white"
-        >
-          {new Date(history.createdAt).toLocaleDateString("ko-KR", {
-            year: "numeric",
-            month: "long",
-            day: "numeric",
-          })}{" "}
-          - {history.contents.title}
-        </li>
+        <Link key={history.id} to={`/history/${history.id}`}>
+          <li className="w-full h-10 px-4 bg-sl-blue rounded-2xl text-base text-sl-white truncate leading-10 text-center">
+            {new Date(history.createdAt).toLocaleDateString("ko-KR", {
+              year: "numeric",
+              month: "long",
+              day: "numeric",
+            })}{" "}
+            - {history.contents.title}
+          </li>
+        </Link>
       ))}
     </ul>
   );

--- a/src/router/index.jsx
+++ b/src/router/index.jsx
@@ -2,6 +2,7 @@ import { createMemoryRouter } from "react-router";
 import App from "../App";
 import SummaryPage from "../pages/SummaryPage";
 import HistoryPage from "../pages/HistoryPage";
+import HistoryDetailPage from "../pages/HistoryDetailPage";
 
 export const router = createMemoryRouter([
   {
@@ -10,6 +11,7 @@ export const router = createMemoryRouter([
     children: [
       { index: true, element: <SummaryPage /> },
       { path: "history", element: <HistoryPage /> },
+      { path: "history/:id", element: <HistoryDetailPage /> },
     ],
   },
 ]);


### PR DESCRIPTION
## 변경 내용
> #14 
### 1. History 상세 페이지 구현
- 히스토리 목록에서 특정 항목 클릭 시 상세 정보를 확인할 수 있는 페이지 추가
- 신규 페이지 컴포넌트: src/pages/HistoryDetailPage.jsx
### 2. 라우팅 추가
- React Router 동적 라우팅 적용
- /history/:id
- useParams를 사용해 URL에서 히스토리 ID 추출
### 3. 목록 → 상세 페이지 연결
- HistoryPage.jsx에서 히스토리 목록 항목을 Link 컴포넌트로 변경
- 클릭 시 해당 히스토리 상세 페이지로 이동
### 4. 데이터 연동
- Chrome Extension Message Passing 패턴 사용
- FETCH_HISTORY_DETAIL 메시지 추가
- 백엔드 API 연동
- GET /histories/:id
- API 응답 구조에 맞게 데이터 처리
- setHistory(response.data);
### 5. UI 구성
- 제목 표시 (text-[32px])
- 요약 날짜 표시(예: 요약 날짜: 2026년 1월 11일)
- 요약 내용 표시
- 하단 고정 “목록으로” 버튼
- 긴 제목 말줄임 처리 (truncate + leading-10 + text-center)
### 6. 접근성 및 UX 개선
- 핵심 콘텐츠를 먼저 읽도록 콘텐츠 영역과 버튼 영역 분리
- 콘텐츠 영역만 스크롤 가능하도록 구성
- 시맨틱 태그 사용으로 스크린 리더 탐색 지원
  - `<h1>`: 제목 (H키로 빠른 탐색 가능)
  - `<p>`: 날짜 및 요약 내용
- 기존 SummaryPage와 동일한 접근성 구조 유지

## 기타 참고 사항
### 구현 UI (SUPABASE 목데이터 활용)
1. 기본 상세 페이지
<img width="537" height="831" alt="image" src="https://github.com/user-attachments/assets/a8717f09-7a17-4a93-8a50-a44d340286fe" />

2. 기본 상세 페이지에서 콘텐츠 영역만 스크롤 가능하도록 구성
<img width="565" height="832" alt="image" src="https://github.com/user-attachments/assets/98683f95-307e-4b00-bc6b-219410ccb3d2" />

3. history 목록 긴 제목 말줄임표 처리
<img width="381" height="835" alt="image" src="https://github.com/user-attachments/assets/e829bbcf-248f-4b55-aab0-b6dc63f22c65" />

### 기술적 결정
- `useEffect` 의존성 관리
  - 의존성 배열에 [id] 포함
  - URL의 ID가 변경될 경우 상세 데이터 재조회
- 레이아웃 구조 분리
  - 콘텐츠 영역과 버튼 영역을 분리하여 스크롤 UX 및 접근성 개선
- API 응답 구조 반영
  - API 응답의 data 자체가 `history` 객체이므로 별도 가공 없이 상태에 저장
### MVP 제약사항 (미구현, 추후 과제)
- MVP 제약사항 (미구현, 추후 과제)
  - UI/UX
    - url 필드 표시 (원본 페이지 링크)
    - `contentType` 표시 (summary / analysis 구분)
    - 파란 버튼 컴포넌트화
    - 목록 항목 버튼과 "목록으로" 버튼 스타일 통합
    - 전체 목록 페이지에서 저장 버튼 제거
    - Header의 로고가 화면을 줄였을 때 깨지는 문제 해결
  - 코드 품질
    - 날짜 포맷팅 유틸 함수 분리
  - 성능 최적화
    - 목록 → 상세 페이지 진입 시 state 전달로 API 호출 제거
    - `/histories/:id` 엔드포인트 삭제 (백엔드)
  
### 테스트
- 수동 테스트 완료
  - 히스토리 목록 → 상세 페이지 이동 확인
  - 제목, 날짜, 요약 정상 표시 확인
  - “목록으로” 클릭 시 목록 페이지 복귀 확인
  - 긴 요약 내용일 경우 스크롤 동작 확인