### PR TITLE
refactor: Header/Footer 조건부 렌더링 및 상태 관리 개선

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,7 @@
     "service_worker": "src/background/background.js",
     "type": "module"
   },
-  "permissions": ["sidePanel"],
+  "permissions": ["sidePanel", "storage"],
   "host_permissions": ["http://localhost:3000/*"],
   "options_page": "src/tabs/settings.html"
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,10 @@ const App = () => {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [summaryStatus, setSummaryStatus] = useState(SUMMARY_STATUS.DEFAULT);
 
+  const handleLogoClick = () => {
+    setSummaryStatus(SUMMARY_STATUS.DEFAULT);
+  };
+
   useEffect(() => {
     const tempToken = import.meta.env.VITE_TEMP_AUTH_TOKEN;
 
@@ -32,7 +36,12 @@ const App = () => {
 
   return (
     <div className="flex flex-col h-screen gap-5 p-5">
-      <Header isLoggedIn={isLoggedIn} summaryStatus={summaryStatus} />
+      <Header
+        isLoggedIn={isLoggedIn}
+        summaryStatus={summaryStatus}
+        currentPath={location.pathname}
+        onLogoClick={handleLogoClick}
+      />
       <main className="flex flex-col items-center gap-2 w-full h-full p-3 border border-sl-blue rounded-xl overflow-y-auto">
         <Outlet context={{ isLoggedIn, summaryStatus, setSummaryStatus }} />
       </main>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,10 +2,12 @@ import { useEffect, useState } from "react";
 import { Outlet, useLocation } from "react-router";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
+import { SUMMARY_STATUS } from "./constants/index.js";
 
 const App = () => {
   const location = useLocation();
   const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [summaryStatus, setSummaryStatus] = useState(SUMMARY_STATUS.DEFAULT);
 
   useEffect(() => {
     const tempToken = import.meta.env.VITE_TEMP_AUTH_TOKEN;
@@ -30,11 +32,15 @@ const App = () => {
 
   return (
     <div className="flex flex-col h-screen gap-5 p-5">
-      <Header isLoggedIn={isLoggedIn} />
+      <Header isLoggedIn={isLoggedIn} summaryStatus={summaryStatus} />
       <main className="flex flex-col items-center gap-2 w-full h-full p-3 border border-sl-blue rounded-xl overflow-y-auto">
-        <Outlet context={{ isLoggedIn }} />
+        <Outlet context={{ isLoggedIn, summaryStatus, setSummaryStatus }} />
       </main>
-      <Footer isLoggedIn={isLoggedIn} currentPath={location.pathname} />
+      <Footer
+        isLoggedIn={isLoggedIn}
+        currentPath={location.pathname}
+        summaryStatus={summaryStatus}
+      />
     </div>
   );
 };

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,15 +1,40 @@
-import { Outlet } from "react-router";
+import { useEffect, useState } from "react";
+import { Outlet, useLocation } from "react-router";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 
 const App = () => {
+  const location = useLocation();
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  useEffect(() => {
+    const tempToken = import.meta.env.VITE_TEMP_AUTH_TOKEN;
+
+    let isMounted = true;
+
+    // TODO: 로그인 연동 후 삭제
+    if (isMounted && tempToken) {
+      chrome.storage.local.set({ token: tempToken });
+    }
+
+    chrome.storage.local.get("token", (result) => {
+      if (isMounted) {
+        setIsLoggedIn(!!result.token);
+      }
+    });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
   return (
     <div className="flex flex-col h-screen gap-5 p-5">
-      <Header />
+      <Header isLoggedIn={isLoggedIn} />
       <main className="flex flex-col items-center gap-2 w-full h-full p-3 border border-sl-blue rounded-xl overflow-y-auto">
-        <Outlet />
+        <Outlet context={{ isLoggedIn }} />
       </main>
-      <Footer />
+      <Footer isLoggedIn={isLoggedIn} currentPath={location.pathname} />
     </div>
   );
 };

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -43,7 +43,7 @@ const App = () => {
         onLogoClick={handleLogoClick}
       />
       <main className="flex flex-col items-center gap-2 w-full h-full p-3 border border-sl-blue rounded-xl overflow-y-auto">
-        <Outlet context={{ isLoggedIn, summaryStatus, setSummaryStatus }} />
+        <Outlet context={{ summaryStatus, setSummaryStatus }} />
       </main>
       <Footer
         isLoggedIn={isLoggedIn}

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router";
 
-const Button = ({ children, bgColor, borderColor, textColor = "text-sl-black", to }) => {
+const Button = ({ children, bgColor, borderColor, textColor = "text-sl-black", to, onClick }) => {
   const className = `flex justify-center items-center w-[65px] h-[30px] ${bgColor} border ${borderColor} rounded-2xl font-medium ${textColor}`;
 
   return to ? (
@@ -8,7 +8,7 @@ const Button = ({ children, bgColor, borderColor, textColor = "text-sl-black", t
       {children}
     </Link>
   ) : (
-    <button type="button" className={className}>
+    <button type="button" onClick={onClick} className={className}>
       {children}
     </button>
   );

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,14 +1,29 @@
 import Button from "./Button";
+import { SUMMARY_STATUS } from "../constants/index.js";
 
-const Footer = () => {
+const Footer = ({ isLoggedIn, currentPath, summaryStatus }) => {
+  const isLoading = summaryStatus === SUMMARY_STATUS.LOADING;
+  const isResult = summaryStatus === SUMMARY_STATUS.RESULT;
+
+  const isSummaryPage = currentPath === "/";
+  const isHistoryDetailPage = currentPath.startsWith("/history/");
+
+  const isSaveButtonVisible = !isLoading && ((isSummaryPage && isResult) || isHistoryDetailPage);
+  const isDeleteButtonVisible =
+    !isLoading && isLoggedIn && ((isSummaryPage && isResult) || isHistoryDetailPage);
+
   return (
     <footer className="flex justify-end gap-x-2">
-      <Button bgColor="bg-sl-white" borderColor="border-sl-blue">
-        저장
-      </Button>
-      <Button bgColor="bg-sl-white" borderColor="border-sl-blue">
-        삭제
-      </Button>
+      {isSaveButtonVisible && (
+        <Button bgColor="bg-sl-white" borderColor="border-sl-blue">
+          저장
+        </Button>
+      )}
+      {isDeleteButtonVisible && (
+        <Button bgColor="bg-sl-white" borderColor="border-sl-blue">
+          삭제
+        </Button>
+      )}
       <Button bgColor="bg-sl-white" borderColor="border-sl-blue">
         닫기
       </Button>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -2,15 +2,17 @@ import Logo from "./Logo";
 import Button from "./Button";
 import { SUMMARY_STATUS } from "../constants/index.js";
 
-const Header = ({ isLoggedIn, summaryStatus }) => {
+const Header = ({ isLoggedIn, summaryStatus, currentPath, onLogoClick }) => {
   const isLoading = summaryStatus === SUMMARY_STATUS.LOADING;
+  const isHistoryPage = currentPath.startsWith("/history");
+  const isHistoryButtonVisible = !isLoading && isLoggedIn && !isHistoryPage;
 
   return (
     <header>
       <div className="flex justify-between">
-        <Logo iconSize={32} textSize={16} spacing="mt-0.5 ml-1" />
+        <Logo iconSize={32} textSize={16} spacing="mt-0.5 ml-1" onClick={onLogoClick} />
         <div className="flex gap-x-2">
-          {!isLoading && isLoggedIn && (
+          {isHistoryButtonVisible && (
             <Button to="/history" bgColor="bg-sl-white" borderColor="border-sl-blue">
               기록
             </Button>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,18 +1,30 @@
 import Logo from "./Logo";
 import Button from "./Button";
+import { SUMMARY_STATUS } from "../constants/index.js";
 
-const Header = () => {
+const Header = ({ isLoggedIn, summaryStatus }) => {
+  const isLoading = summaryStatus === SUMMARY_STATUS.LOADING;
+
   return (
     <header>
       <div className="flex justify-between">
         <Logo iconSize={32} textSize={16} spacing="mt-0.5 ml-1" />
         <div className="flex gap-x-2">
-          <Button to="/history" bgColor="bg-sl-white" borderColor="border-sl-blue">
-            기록
-          </Button>
-          <Button bgColor="bg-sl-white" borderColor="border-sl-blue">
-            로그인
-          </Button>
+          {!isLoading && isLoggedIn && (
+            <Button to="/history" bgColor="bg-sl-white" borderColor="border-sl-blue">
+              기록
+            </Button>
+          )}
+          {!isLoading && !isLoggedIn && (
+            <Button bgColor="bg-sl-white" borderColor="border-sl-blue">
+              로그인
+            </Button>
+          )}
+          {!isLoading && isLoggedIn && (
+            <Button bgColor="bg-sl-white" borderColor="border-sl-blue">
+              로그아웃
+            </Button>
+          )}
           <Button bgColor="bg-sl-white" borderColor="border-sl-blue">
             설정
           </Button>

--- a/src/components/Logo.jsx
+++ b/src/components/Logo.jsx
@@ -1,6 +1,8 @@
-const Logo = ({ iconSize, textSize, spacing }) => {
+import { Link } from "react-router";
+
+const Logo = ({ iconSize, textSize, spacing, onClick }) => {
   return (
-    <a href="/" className="flex">
+    <Link to="/" onClick={onClick} className="flex">
       <img
         src={`/images/icons/spreadlove-icon-${iconSize}.png`}
         alt="스프레드 러브"
@@ -13,7 +15,7 @@ const Logo = ({ iconSize, textSize, spacing }) => {
       <span aria-hidden="true" className={`mt-0.5 font-semibold text-[${textSize}px] text-sl-red`}>
         Love
       </span>
-    </a>
+    </Link>
   );
 };
 

--- a/src/pages/SummaryPage.jsx
+++ b/src/pages/SummaryPage.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
+import { useOutletContext } from "react-router";
 import LoadingSpinner from "../components/LoadingSpinner";
-import { SUMMARY_STATUS, TEST_DATA } from "../constants/Index";
+import { SUMMARY_STATUS, TEST_DATA } from "../constants/index";
 
 const blobToBase64 = (blob) => {
   return new Promise((resolve) => {
@@ -12,11 +13,11 @@ const blobToBase64 = (blob) => {
 };
 
 const SummaryPage = () => {
-  const [status, setStatus] = useState(SUMMARY_STATUS.DEFAULT);
+  const { summaryStatus, setSummaryStatus } = useOutletContext();
   const [summaryData, setSummaryData] = useState(null);
 
   const handleSummaryClick = async () => {
-    setStatus(SUMMARY_STATUS.LOADING);
+    setSummaryStatus(SUMMARY_STATUS.LOADING);
 
     const testItem = TEST_DATA.MUSINSA;
     const response = await fetch(testItem.image);
@@ -34,17 +35,17 @@ const SummaryPage = () => {
       (response) => {
         if (response?.success) {
           setSummaryData(response.data);
-          setStatus(SUMMARY_STATUS.RESULT);
+          setSummaryStatus(SUMMARY_STATUS.RESULT);
         } else {
           console.error("요약 실패:", response?.error);
-          setStatus(SUMMARY_STATUS.DEFAULT);
+          setSummaryStatus(SUMMARY_STATUS.DEFAULT);
         }
       },
     );
   };
   return (
     <div className="flex flex-col items-center justify-center w-full h-full">
-      {status === SUMMARY_STATUS.DEFAULT && (
+      {summaryStatus === SUMMARY_STATUS.DEFAULT && (
         <button
           type="button"
           onClick={handleSummaryClick}
@@ -54,8 +55,10 @@ const SummaryPage = () => {
           <span>이 페이지 요약하기</span>
         </button>
       )}
-      {status === SUMMARY_STATUS.LOADING && <LoadingSpinner message={"페이지를 요약중입니다..."} />}
-      {status === SUMMARY_STATUS.RESULT && summaryData && (
+      {summaryStatus === SUMMARY_STATUS.LOADING && (
+        <LoadingSpinner message={"페이지를 요약중입니다..."} />
+      )}
+      {summaryStatus === SUMMARY_STATUS.RESULT && summaryData && (
         <div className="flex flex-col gap-4">
           <h1 className="text-[32px]">{summaryData.title}</h1>
           <p className="text-2xl">{summaryData.summary}</p>

--- a/src/pages/SummaryPage.jsx
+++ b/src/pages/SummaryPage.jsx
@@ -34,6 +34,7 @@ const SummaryPage = () => {
       },
       (response) => {
         if (response?.success) {
+          if (summaryStatus !== SUMMARY_STATUS.LOADING) return;
           setSummaryData(response.data);
           setSummaryStatus(SUMMARY_STATUS.RESULT);
         } else {
@@ -43,6 +44,7 @@ const SummaryPage = () => {
       },
     );
   };
+
   return (
     <div className="flex flex-col items-center justify-center w-full h-full">
       {summaryStatus === SUMMARY_STATUS.DEFAULT && (

--- a/src/pages/SummaryPage.jsx
+++ b/src/pages/SummaryPage.jsx
@@ -34,12 +34,19 @@ const SummaryPage = () => {
       },
       (response) => {
         if (response?.success) {
-          if (summaryStatus !== SUMMARY_STATUS.LOADING) return;
           setSummaryData(response.data);
-          setSummaryStatus(SUMMARY_STATUS.RESULT);
+
+          setSummaryStatus((currentStatus) => {
+            if (currentStatus !== SUMMARY_STATUS.LOADING) {
+              return currentStatus;
+            }
+
+            return SUMMARY_STATUS.RESULT;
+          });
         } else {
           console.error("요약 실패:", response?.error);
-          setSummaryStatus(SUMMARY_STATUS.DEFAULT);
+
+          return SUMMARY_STATUS.DEFAULT;
         }
       },
     );


### PR DESCRIPTION
## 변경 내용
> #17
- [x] App.jsx에 summaryStatus 상태 중앙화
- [x]  Header 조건부 렌더링 (로그인 상태, 페이지별 버튼 표시)
- [x]  Footer 조건부 렌더링 (저장/삭제 버튼 조건부 표시)
- [x]  Logo 클릭 시 메인 화면 이동 및 상태 초기화
- [x]  manifest.json에 storage 권한 추가
- [x]  API 응답 시 상태 체크로 race condition 방지

## 기타 참고 사항
Header/Footer에서 상태에 따른 조건부 렌더링이 필요해서 급하게 이슈를 생성하여 작업했습니다. 주요 내용으로는 summaryStatus를 App.jsx에서 관리하도록 변경했습니다.

App.jsx -> Header : props로 상태 전달
App.jsx -> Outlet  : context로(요약 내용, 로그인 상태) 전달
App.jsx -> Footer : props로 상태 전달


처음 마크업 단계에서 컴포넌트 분리를 신중하게 했으면 좋았을 것 같습니다...
다. 초기에 Header/Footer/Logo/main 으로 분리하거나 묶어버려서 나중에 상태 공유가 필요해졌을 때 오히려 구조가 복잡해졌습니다.. 일단은 조건문으로 해결했지만, 추후에 리팩토링이 필요하면 구조를 바꿔야할 것 같습니다.

