### PR TITLE
feat: 히스토리 목록 삭제

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ const App = () => {
   const location = useLocation();
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [summaryStatus, setSummaryStatus] = useState(SUMMARY_STATUS.DEFAULT);
+  const [summaryData, setSummaryData] = useState(null);
 
   const handleLogoClick = () => {
     setSummaryStatus(SUMMARY_STATUS.DEFAULT);
@@ -43,7 +44,7 @@ const App = () => {
         onLogoClick={handleLogoClick}
       />
       <main className="flex flex-col items-center gap-2 w-full h-full p-3 border border-sl-blue rounded-xl overflow-y-auto">
-        <Outlet context={{ summaryStatus, setSummaryStatus }} />
+        <Outlet context={{ summaryStatus, setSummaryStatus, summaryData, setSummaryData }} />
       </main>
       <Footer
         isLoggedIn={isLoggedIn}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,32 @@ const App = () => {
   const location = useLocation();
   const navigate = useNavigate();
 
+  const getHistoryId = () => {
+    if (location.pathname === "/") {
+      return summaryData.historyId;
+    }
+
+    if (location.pathname.startsWith("/history/")) {
+      const match = matchPath("/history/:id", location.pathname);
+      return match.params.id;
+    }
+
+    return null;
+  };
+
+  const afterDeleteAction = () => {
+    setIsModalOpen(false);
+
+    if (location.pathname === "/") {
+      setSummaryStatus(SUMMARY_STATUS.DEFAULT);
+      setSummaryData(null);
+    }
+
+    if (location.pathname.startsWith("/history/")) {
+      navigate("/history");
+    }
+  };
+
   const handleLogoClick = () => {
     setSummaryStatus(SUMMARY_STATUS.DEFAULT);
   };
@@ -26,32 +52,19 @@ const App = () => {
     setIsModalOpen(false);
   };
 
-  const handleModalDeleteButton = async () => {
-    const getHistoryId = () => {
-      if (location.pathname === "/") {
-        return summaryData.historyId;
-      }
+  const handleModalDeleteButton = () => {
+    const historyId = getHistoryId();
+    chrome.runtime.sendMessage(
+      {
+        type: "DELETE_HISTORY",
+        payload: { historyId },
+      },
+      (response) => {
+        if (!response.success) return;
 
-      if (location.pathname.startsWith("/history/")) {
-        const match = matchPath("/history/:id", location.pathname);
-
-        return match.params.id;
-      }
-
-      return null;
-    };
-
-    getHistoryId();
-    setIsModalOpen(false);
-
-    if (location.pathname === "/") {
-      setSummaryStatus(SUMMARY_STATUS.DEFAULT);
-      setSummaryData(null);
-    }
-
-    if (location.pathname.startsWith("/history/")) {
-      navigate("/history");
-    }
+        afterDeleteAction();
+      },
+    );
   };
 
   useEffect(() => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,17 +1,57 @@
 import { useEffect, useState } from "react";
-import { Outlet, useLocation } from "react-router";
+import { Outlet, useLocation, useNavigate, matchPath } from "react-router";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
+import DeleteModal from "./components/DeleteModal";
 import { SUMMARY_STATUS } from "./constants/index.js";
 
 const App = () => {
-  const location = useLocation();
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [summaryStatus, setSummaryStatus] = useState(SUMMARY_STATUS.DEFAULT);
   const [summaryData, setSummaryData] = useState(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const location = useLocation();
+  const navigate = useNavigate();
 
   const handleLogoClick = () => {
     setSummaryStatus(SUMMARY_STATUS.DEFAULT);
+  };
+
+  const handleFooterDeleteButton = () => {
+    setIsModalOpen(true);
+  };
+
+  const handleModalCancelButton = () => {
+    setIsModalOpen(false);
+  };
+
+  const handleModalDeleteButton = async () => {
+    const getHistoryId = () => {
+      if (location.pathname === "/") {
+        return summaryData.historyId;
+      }
+
+      if (location.pathname.startsWith("/history/")) {
+        const match = matchPath("/history/:id", location.pathname);
+
+        return match.params.id;
+      }
+
+      return null;
+    };
+
+    getHistoryId();
+    setIsModalOpen(false);
+
+    if (location.pathname === "/") {
+      setSummaryStatus(SUMMARY_STATUS.DEFAULT);
+      setSummaryData(null);
+    }
+
+    if (location.pathname.startsWith("/history/")) {
+      navigate("/history");
+    }
   };
 
   useEffect(() => {
@@ -50,6 +90,12 @@ const App = () => {
         isLoggedIn={isLoggedIn}
         currentPath={location.pathname}
         summaryStatus={summaryStatus}
+        onDeleteClick={handleFooterDeleteButton}
+      />
+      <DeleteModal
+        isOpen={isModalOpen}
+        onCancel={handleModalCancelButton}
+        onDelete={handleModalDeleteButton}
       />
     </div>
   );

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -40,19 +40,38 @@ const handleFetchHistoryDetail = async (payload, sendResponse) => {
   }
 };
 
+const handleDeleteHistory = async (payload, sendResponse) => {
+  try {
+    const data = await api.delete(`histories/${payload.historyId}`).json();
+
+    sendResponse(data);
+  } catch (error) {
+    sendResponse({ success: false, error: error.message });
+  }
+};
+
 const handleMessage = (message, sender, sendResponse) => {
   if (message.type === "SUMMARIZE") {
     handleSummarizeMessage(message.payload, sendResponse);
+
+    return true;
+  }
+
+  if (message.type === "DELETE_HISTORY") {
+    handleDeleteHistory(message.payload, sendResponse);
+
     return true;
   }
 
   if (message.type === "FETCH_HISTORIES") {
     handleFetchHistories(sendResponse);
+
     return true;
   }
 
   if (message.type === "FETCH_HISTORY_DETAIL") {
     handleFetchHistoryDetail(message.payload, sendResponse);
+
     return true;
   }
 };

--- a/src/components/DeleteModal.jsx
+++ b/src/components/DeleteModal.jsx
@@ -1,6 +1,8 @@
 import Button from "./Button";
 
-const DeleteModal = () => {
+const DeleteModal = ({ isOpen, onCancel, onDelete }) => {
+  if (!isOpen) return null;
+
   return (
     <div className="fixed inset-0 z-10 flex items-end justify-center">
       <div className="absolute inset-0 bg-sl-black/85"></div>
@@ -10,10 +12,15 @@ const DeleteModal = () => {
           이 채팅을 삭제하시겠습니까? 이 작업은 취소할 수 없습니다.
         </p>
         <div className="flex justify-end gap-3">
-          <Button bgColor="bg-sl-white" borderColor="border-sl-blue">
+          <Button bgColor="bg-sl-white" borderColor="border-sl-blue" onClick={onCancel}>
             취소
           </Button>
-          <Button bgColor="bg-sl-red" borderColor="border-sl-red" textColor="text-sl-white">
+          <Button
+            bgColor="bg-sl-red"
+            borderColor="border-sl-red"
+            textColor="text-sl-white"
+            onClick={onDelete}
+          >
             삭제
           </Button>
         </div>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,7 +1,7 @@
 import Button from "./Button";
 import { SUMMARY_STATUS } from "../constants/index.js";
 
-const Footer = ({ isLoggedIn, currentPath, summaryStatus }) => {
+const Footer = ({ isLoggedIn, currentPath, summaryStatus, onDeleteClick }) => {
   const isLoading = summaryStatus === SUMMARY_STATUS.LOADING;
   const isResult = summaryStatus === SUMMARY_STATUS.RESULT;
 
@@ -20,7 +20,7 @@ const Footer = ({ isLoggedIn, currentPath, summaryStatus }) => {
         </Button>
       )}
       {isDeleteButtonVisible && (
-        <Button bgColor="bg-sl-white" borderColor="border-sl-blue">
+        <Button bgColor="bg-sl-white" borderColor="border-sl-blue" onClick={onDeleteClick}>
           삭제
         </Button>
       )}

--- a/src/pages/SummaryPage.jsx
+++ b/src/pages/SummaryPage.jsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useOutletContext } from "react-router";
 import LoadingSpinner from "../components/LoadingSpinner";
 import { SUMMARY_STATUS, TEST_DATA } from "../constants/index";
@@ -13,8 +12,7 @@ const blobToBase64 = (blob) => {
 };
 
 const SummaryPage = () => {
-  const { summaryStatus, setSummaryStatus } = useOutletContext();
-  const [summaryData, setSummaryData] = useState(null);
+  const { summaryStatus, setSummaryStatus, summaryData, setSummaryData } = useOutletContext();
 
   const handleSummaryClick = async () => {
     setSummaryStatus(SUMMARY_STATUS.LOADING);


### PR DESCRIPTION
## 변경 내용
> #16
 - [x] DeleteModal에 props 추가 (isOpen, onCancel, onDelete)
 - [x] summaryData 상태를 SummaryPage에서 App.jsx로 이동
 - [x] App.jsx에서 삭제 모달 상태 관리 (isModalOpen)
 - [x] Footer 삭제 버튼에 onDeleteClick 이벤트 연결
 - [x] background.js에 DELETE_HISTORY 핸들러 추가
 - [x] 삭제 확인 시 DELETE API 호출 및 후처리 구현
 - [x] SummaryPage: summaryStatus를 DEFAULT로 초기화
 

## 기타 참고 사항
삭제 버튼이 Footer에 위치해 있고, DeleteModal도 전역에서 관리해야 해서 App.jsx에서 상태를 중앙 관리하도록 구현했습니다.
그 이유는 Footer가 App의 직계 하위 컴포넌트고, 페이지들은 Outlet 안에 있어서 이벤트 전달이 App을 거쳐야 했습니다. 그리고 삭제 후 동작이 summuaryPage는 상태 초기화, HistoryDetailPage에서는 목록으로 이동이라서 pathname으로 분기해서 한 곳에서 처리하는 게 깔끔할 것 같았습니다.

현재 App.jsx에서 많은 역할을 하고 있기 때문에 추후 리팩토링이 필요합니다.
