### PR TITLE
feat: 이미지 캡처 기능 구현

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -37,7 +37,7 @@
       "js": ["src/content/content.js"]
     }
   ],
-  "permissions": ["sidePanel", "storage"],
+  "permissions": ["sidePanel", "storage", "activeTab"],
   "host_permissions": ["http://localhost:3000/*", "<all_urls>"],
   "options_page": "src/tabs/settings.html"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -38,6 +38,6 @@
     }
   ],
   "permissions": ["sidePanel", "storage", "activeTab"],
-  "host_permissions": ["http://localhost:3000/*", "<all_urls>"],
+  "host_permissions": ["http://localhost:3000/*"],
   "options_page": "src/tabs/settings.html"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,22 @@
     "service_worker": "src/background/background.js",
     "type": "module"
   },
+  "commands": {
+    "analyze-image": {
+      "suggested_key": {
+        "default": "Alt+I",
+        "mac": "Alt+I"
+      },
+      "description": "포커스된 이미지 분석"
+    }
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["src/content/content.js"]
+    }
+  ],
   "permissions": ["sidePanel", "storage"],
-  "host_permissions": ["http://localhost:3000/*"],
+  "host_permissions": ["http://localhost:3000/*", "<all_urls>"],
   "options_page": "src/tabs/settings.html"
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,13 +3,15 @@ import { Outlet, useLocation, useNavigate, matchPath } from "react-router";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 import DeleteModal from "./components/DeleteModal";
-import { SUMMARY_STATUS } from "./constants/index.js";
+import { SUMMARY_STATUS, IMAGE_ANALYSIS_STATUS } from "./constants/index.js";
 
 const App = () => {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [summaryStatus, setSummaryStatus] = useState(SUMMARY_STATUS.DEFAULT);
   const [summaryData, setSummaryData] = useState(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [analysisStatus, setAnalysisStatus] = useState(IMAGE_ANALYSIS_STATUS.LOADING);
+  const [analysisData, setAnalysisData] = useState(null);
 
   const location = useLocation();
   const navigate = useNavigate();
@@ -22,6 +24,10 @@ const App = () => {
     if (location.pathname.startsWith("/history/")) {
       const match = matchPath("/history/:id", location.pathname);
       return match.params.id;
+    }
+
+    if (location.pathname === "/analysis") {
+      return analysisData?.data?.historyId;
     }
 
     return null;
@@ -37,6 +43,12 @@ const App = () => {
 
     if (location.pathname.startsWith("/history/")) {
       navigate("/history");
+    }
+
+    if (location.pathname === "/analysis") {
+      setAnalysisStatus(IMAGE_ANALYSIS_STATUS.LOADING);
+      setAnalysisData(null);
+      navigate("/");
     }
   };
 
@@ -88,6 +100,24 @@ const App = () => {
     };
   }, []);
 
+  useEffect(() => {
+    let isMounted = true;
+
+    const checkPendingAnalysis = async () => {
+      const { pendingImageAnalysis } = await chrome.storage.local.get("pendingImageAnalysis");
+
+      if (isMounted && pendingImageAnalysis) {
+        navigate("/analysis");
+      }
+    };
+
+    checkPendingAnalysis();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
   return (
     <div className="flex flex-col h-screen gap-5 p-5">
       <Header
@@ -97,12 +127,24 @@ const App = () => {
         onLogoClick={handleLogoClick}
       />
       <main className="flex flex-col items-center gap-2 w-full h-full p-3 border border-sl-blue rounded-xl overflow-y-auto">
-        <Outlet context={{ summaryStatus, setSummaryStatus, summaryData, setSummaryData }} />
+        <Outlet
+          context={{
+            summaryStatus,
+            setSummaryStatus,
+            summaryData,
+            setSummaryData,
+            analysisStatus,
+            setAnalysisStatus,
+            analysisData,
+            setAnalysisData,
+          }}
+        />
       </main>
       <Footer
         isLoggedIn={isLoggedIn}
         currentPath={location.pathname}
         summaryStatus={summaryStatus}
+        analysisStatus={analysisStatus}
         onDeleteClick={handleFooterDeleteButton}
       />
       <DeleteModal

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -55,14 +55,11 @@ const handleAnalyzeImage = async (payload, sendResponse) => {
   const { imageUrl, pageUrl } = payload;
 
   try {
-    const imageResponse = await fetch(imageUrl);
-    const imageBlob = await imageResponse.blob();
-
-    const formData = new FormData();
-    formData.append("image", imageBlob, "analyzed-image.png");
-    formData.append("pageUrl", pageUrl);
-
-    const data = await api.post("analyses", { body: formData }).json();
+    const data = await api
+      .post("analyses", {
+        json: { imageUrl, pageUrl },
+      })
+      .json();
 
     sendResponse({ success: true, data });
   } catch (error) {

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -1,6 +1,7 @@
 import { api } from "../api/client.js";
 
 const sidePanelConfig = { openPanelOnActionClick: true };
+const focusedImages = new Map();
 
 const handleSummarizeMessage = async (payload, sendResponse) => {
   const { url, imageBase64 } = payload;
@@ -50,7 +51,40 @@ const handleDeleteHistory = async (payload, sendResponse) => {
   }
 };
 
+const handleAnalyzeImage = async (payload, sendResponse) => {
+  const { imageUrl, pageUrl } = payload;
+
+  try {
+    const imageResponse = await fetch(imageUrl);
+    const imageBlob = await imageResponse.blob();
+
+    const formData = new FormData();
+    formData.append("image", imageBlob, "analyzed-image.png");
+    formData.append("pageUrl", pageUrl);
+
+    const data = await api.post("analyses", { body: formData }).json();
+
+    sendResponse({ success: true, data });
+  } catch (error) {
+    sendResponse({ success: false, error: error.message });
+  }
+};
 const handleMessage = (message, sender, sendResponse) => {
+  if (message.type === "IMAGE_FOCUSED") {
+    focusedImages.set(sender.tab.id, {
+      imageUrl: message.imageUrl,
+      pageUrl: message.pageUrl,
+    });
+
+    return true;
+  }
+
+  if (message.type === "IMAGE_UNFOCUSED") {
+    focusedImages.delete(sender.tab.id);
+
+    return true;
+  }
+
   if (message.type === "SUMMARIZE") {
     handleSummarizeMessage(message.payload, sendResponse);
 
@@ -74,11 +108,40 @@ const handleMessage = (message, sender, sendResponse) => {
 
     return true;
   }
+
+  if (message.type === "ANALYZE_IMAGE") {
+    handleAnalyzeImage(message.payload, sendResponse);
+
+    return true;
+  }
+};
+const handleAnalyzeImageCommand = async (tab) => {
+  const focusedImage = focusedImages.get(tab.id);
+
+  if (!focusedImage) {
+    return;
+  }
+
+  try {
+    await chrome.sidePanel.open({ tabId: tab.id });
+  } catch (error) {
+    console.error("[Spread Love] Side Panel 열기 실패:", error);
+    return;
+  }
+
+  await chrome.storage.local.remove("pendingImageAnalysis");
+  await chrome.storage.local.set({ pendingImageAnalysis: focusedImage });
 };
 
 const init = () => {
   chrome.sidePanel.setPanelBehavior(sidePanelConfig).catch((error) => console.error(error));
   chrome.runtime.onMessage.addListener(handleMessage);
+
+  chrome.commands.onCommand.addListener((command, tab) => {
+    if (command === "analyze-image") {
+      handleAnalyzeImageCommand(tab);
+    }
+  });
 };
 
 init();

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,16 +1,22 @@
 import Button from "./Button";
-import { SUMMARY_STATUS } from "../constants/index.js";
+import { SUMMARY_STATUS, IMAGE_ANALYSIS_STATUS } from "../constants/index.js";
 
-const Footer = ({ isLoggedIn, currentPath, summaryStatus, onDeleteClick }) => {
+const Footer = ({ isLoggedIn, currentPath, summaryStatus, analysisStatus, onDeleteClick }) => {
   const isLoading = summaryStatus === SUMMARY_STATUS.LOADING;
   const isResult = summaryStatus === SUMMARY_STATUS.RESULT;
 
   const isSummaryPage = currentPath === "/";
   const isHistoryDetailPage = currentPath.startsWith("/history/");
 
-  const isSaveButtonVisible = !isLoading && ((isSummaryPage && isResult) || isHistoryDetailPage);
+  const isAnalysisPage = currentPath === "/analysis";
+  const isAnalysisResult = analysisStatus === IMAGE_ANALYSIS_STATUS.RESULT;
+  const isSaveButtonVisible =
+    !isLoading &&
+    ((isSummaryPage && isResult) || isHistoryDetailPage || (isAnalysisPage && isAnalysisResult));
   const isDeleteButtonVisible =
-    !isLoading && isLoggedIn && ((isSummaryPage && isResult) || isHistoryDetailPage);
+    !isLoading &&
+    isLoggedIn &&
+    ((isSummaryPage && isResult) || isHistoryDetailPage || (isAnalysisPage && isAnalysisResult));
 
   return (
     <footer className="flex justify-end gap-x-2">

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -4,6 +4,12 @@ const SUMMARY_STATUS = {
   RESULT: "result",
 };
 
+const IMAGE_ANALYSIS_STATUS = {
+  LOADING: "loading",
+  RESULT: "result",
+  ERROR: "error",
+};
+
 const TEST_DATA = {
   YONHAP_NEWS: {
     url: "https://www.yna.co.kr/view/AKR20231213165600007",
@@ -19,4 +25,4 @@ const TEST_DATA = {
   },
 };
 
-export { SUMMARY_STATUS, TEST_DATA };
+export { SUMMARY_STATUS, IMAGE_ANALYSIS_STATUS, TEST_DATA };

--- a/src/content/content.js
+++ b/src/content/content.js
@@ -1,0 +1,22 @@
+const handleGetFocusedImage = (message, sender, sendResponse) => {
+  if (message.type !== "GET_FOCUSED_IMAGE") {
+    return;
+  }
+
+  const focusedElement = document.activeElement;
+  const isImage = focusedElement && focusedElement.tagName === "IMG";
+  const hasAlt = focusedElement && focusedElement.alt && focusedElement.alt.trim();
+
+  if (!isImage || hasAlt) {
+    sendResponse({ hasImage: false });
+
+    return;
+  }
+
+  sendResponse({
+    hasImage: true,
+    imageUrl: focusedElement.currentSrc || focusedElement.src,
+    pageUrl: window.location.href,
+  });
+};
+chrome.runtime.onMessage.addListener(handleGetFocusedImage);

--- a/src/content/content.js
+++ b/src/content/content.js
@@ -1,14 +1,17 @@
 const handleFocusIn = (event) => {
-  const element = event.target;
-  const hasAlt = element.alt && element.alt.trim();
+  const targetElement = event.target;
+  const imageElement =
+    (targetElement.tagName === "IMG" && targetElement) || targetElement.querySelector("img");
 
-  if (element.tagName !== "IMG") return;
+  if (!imageElement) return;
+
+  const hasAlt = imageElement.alt && imageElement.alt.trim();
 
   if (hasAlt) return;
 
   chrome.runtime.sendMessage({
     type: "IMAGE_FOCUSED",
-    imageUrl: element.currentSrc || element.src,
+    imageUrl: imageElement.currentSrc || imageElement.src,
     pageUrl: window.location.href,
   });
 };

--- a/src/content/content.js
+++ b/src/content/content.js
@@ -1,17 +1,30 @@
+const handleFocusIn = (event) => {
+  const element = event.target;
+  const hasAlt = element.alt && element.alt.trim();
+
+  if (element.tagName !== "IMG") return;
+
+  if (hasAlt) return;
+
+  chrome.runtime.sendMessage({
+    type: "IMAGE_FOCUSED",
+    imageUrl: element.currentSrc || element.src,
+    pageUrl: window.location.href,
+  });
+};
+
+const handleFocusOut = () => {
+  chrome.runtime.sendMessage({ type: "IMAGE_UNFOCUSED" });
+};
+
 const handleGetFocusedImage = (message, sender, sendResponse) => {
-  if (message.type !== "GET_FOCUSED_IMAGE") {
-    return;
-  }
+  if (message.type !== "GET_FOCUSED_IMAGE") return;
 
   const focusedElement = document.activeElement;
   const isImage = focusedElement && focusedElement.tagName === "IMG";
   const hasAlt = focusedElement && focusedElement.alt && focusedElement.alt.trim();
 
-  if (!isImage || hasAlt) {
-    sendResponse({ hasImage: false });
-
-    return;
-  }
+  if (!isImage || hasAlt) return sendResponse({ hasImage: false });
 
   sendResponse({
     hasImage: true,
@@ -19,4 +32,7 @@ const handleGetFocusedImage = (message, sender, sendResponse) => {
     pageUrl: window.location.href,
   });
 };
+
 chrome.runtime.onMessage.addListener(handleGetFocusedImage);
+document.addEventListener("focusin", handleFocusIn);
+document.addEventListener("focusout", handleFocusOut);

--- a/src/pages/ImageAnalysisPage.jsx
+++ b/src/pages/ImageAnalysisPage.jsx
@@ -1,0 +1,79 @@
+import { useState, useEffect } from "react";
+import { useOutletContext } from "react-router";
+import LoadingSpinner from "../components/LoadingSpinner";
+import { IMAGE_ANALYSIS_STATUS } from "../constants/index";
+
+const ImageAnalysisPage = () => {
+  const { analysisStatus, setAnalysisStatus, analysisData, setAnalysisData } = useOutletContext();
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let isActive = true;
+
+    const analyzeImage = async () => {
+      const { pendingImageAnalysis } = await chrome.storage.local.get("pendingImageAnalysis");
+
+      if (!isActive) return;
+
+      if (!pendingImageAnalysis) {
+        setError("분석할 이미지 정보가 없습니다");
+        setAnalysisStatus(IMAGE_ANALYSIS_STATUS.ERROR);
+
+        return;
+      }
+
+      chrome.runtime.sendMessage(
+        {
+          type: "ANALYZE_IMAGE",
+          payload: {
+            imageUrl: pendingImageAnalysis.imageUrl,
+            pageUrl: pendingImageAnalysis.pageUrl,
+          },
+        },
+        (response) => {
+          if (!isActive) return;
+
+          chrome.storage.local.remove("pendingImageAnalysis");
+
+          if (response && response.success) {
+            console.log("[Spread Love] 분석 결과:", response.data);
+            setAnalysisData(response.data);
+            setAnalysisStatus(IMAGE_ANALYSIS_STATUS.RESULT);
+          } else {
+            setError(response?.error || "이미지 분석에 실패했습니다");
+            setAnalysisStatus(IMAGE_ANALYSIS_STATUS.ERROR);
+          }
+        },
+      );
+    };
+
+    analyzeImage();
+
+    return () => {
+      isActive = false;
+    };
+  }, []);
+  return (
+    <div className="flex flex-col items-center justify-center w-full h-full">
+      {analysisStatus === IMAGE_ANALYSIS_STATUS.LOADING && (
+        <LoadingSpinner message="이미지를 분석중입니다..." />
+      )}
+
+      {analysisStatus === IMAGE_ANALYSIS_STATUS.RESULT && analysisData && (
+        <div className="flex flex-col gap-4">
+          <h1 className="text-[32px]">{analysisData.data.title}</h1>
+          <p className="text-2xl">{analysisData.data.summary}</p>
+        </div>
+      )}
+
+      {analysisStatus === IMAGE_ANALYSIS_STATUS.ERROR && (
+        <div className="flex flex-col gap-4">
+          <h1 className="text-[32px] font-bold text-sl-red">오류</h1>
+          <p className="text-xl">{error}</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ImageAnalysisPage;

--- a/src/router/index.jsx
+++ b/src/router/index.jsx
@@ -3,6 +3,7 @@ import App from "../App";
 import SummaryPage from "../pages/SummaryPage";
 import HistoryPage from "../pages/HistoryPage";
 import HistoryDetailPage from "../pages/HistoryDetailPage";
+import ImageAnalysisPage from "../pages/ImageAnalysisPage";
 
 export const router = createMemoryRouter([
   {
@@ -12,6 +13,7 @@ export const router = createMemoryRouter([
       { index: true, element: <SummaryPage /> },
       { path: "history", element: <HistoryPage /> },
       { path: "history/:id", element: <HistoryDetailPage /> },
+      { path: "analysis", element: <ImageAnalysisPage /> },
     ],
   },
 ]);


### PR DESCRIPTION
## 변경 내용
> #20
- [x]  manifest.json에 host_permissions, commands, content_scripts, activeTab 추가
- [x]  Content Script 생성: 이미지 포커스 상태 추적 
- [x] background.js에 포커스 상태 저장 및 단축키 핸들러 추가
- [x] background.js에 ANALYZE_IMAGE API 핸들러 추가
- [x] ImageAnalysisPage.jsx 컴포넌트 생성
- [x] router/index.jsx에 /analysis 라우트 추가
- [x] App.jsx에서 analysisStatus 전역으로 관리
- [X] Footer에 분석 페이지 저장/삭제 버튼 조건 추가

## 기타 참고 사항
alt 값이 없는 이미지에 포커스될 때만 단축키가 실행되는 것을 확인했습니다.

Chrome의 sidePanel.open() API가 사용자 제스처 직후에만 작동하는 제한이 있어서 Content Script에서 포커스 상태를 미리 Background에 알리고, Background는 동기적으로 상태를 확인한 후 Side Panel을 여는 방식으로 구현했습니다.

현재 SVG 이미지를 서버로 전송하면 400 에러가 발생합니다. 조사 해보니 AI Vision API가 SVG 형식을 지원하지 않기 때문이며 백엔드에서 SVG → PNG 변환 로직을 추가해야 합니다.
해당 부분 이슈로 등록하겠습니다.

### 참고문서 
#### 링크
https://platform.openai.com/docs/guides/images-vision
#### 해당 내용 설명 이미지
- PNG, JPEG, WEBP, GIF 형식만 지원한다고 합니다.
<img width="934" height="421" alt="image" src="https://github.com/user-attachments/assets/edea1eb2-d266-4486-b8f4-2008caf4eccc" />


