### PR TITLE
feat: 사용자 화면 캡처 기능 구현

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -38,6 +38,7 @@
     }
   ],
   "permissions": ["sidePanel", "storage", "activeTab"],
+  "optional_host_permissions": ["<all_urls>"],
   "host_permissions": ["http://localhost:3000/*"],
   "options_page": "src/tabs/settings.html"
 }

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -3,16 +3,32 @@ import { api } from "../api/client.js";
 const sidePanelConfig = { openPanelOnActionClick: true };
 const focusedImages = new Map();
 
-const handleSummarizeMessage = async (payload, sendResponse) => {
-  const { url, imageBase64 } = payload;
-  const response = await fetch(imageBase64);
-  const imageBlob = await response.blob();
+const captureVisibleTab = () => {
+  return new Promise((resolve, reject) => {
+    chrome.tabs.captureVisibleTab(null, { format: "png" }, (dataUrl) => {
+      if (chrome.runtime.lastError) {
+        reject(new Error(chrome.runtime.lastError.message));
 
-  const formData = new FormData();
-  formData.append("url", url);
-  formData.append("image", imageBlob, "screenshot.png");
+        return;
+      }
+      resolve(dataUrl);
+    });
+  });
+};
 
+const handleSummarizeMessage = async (sendResponse) => {
   try {
+    const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    const url = activeTab.url;
+
+    const imageBase64 = await captureVisibleTab();
+    const response = await fetch(imageBase64);
+    const imageBlob = await response.blob();
+
+    const formData = new FormData();
+    formData.append("url", url);
+    formData.append("image", imageBlob, "screenshot.png");
+
     const data = await api.post("summaries", { body: formData }).json();
 
     sendResponse(data);
@@ -83,7 +99,7 @@ const handleMessage = (message, sender, sendResponse) => {
   }
 
   if (message.type === "SUMMARIZE") {
-    handleSummarizeMessage(message.payload, sendResponse);
+    handleSummarizeMessage(sendResponse);
 
     return true;
   }

--- a/src/pages/SummaryPage.jsx
+++ b/src/pages/SummaryPage.jsx
@@ -1,53 +1,39 @@
 import { useOutletContext } from "react-router";
 import LoadingSpinner from "../components/LoadingSpinner";
-import { SUMMARY_STATUS, TEST_DATA } from "../constants/index";
-
-const blobToBase64 = (blob) => {
-  return new Promise((resolve) => {
-    const reader = new FileReader();
-
-    reader.onloadend = () => resolve(reader.result);
-    reader.readAsDataURL(blob);
-  });
-};
+import { SUMMARY_STATUS } from "../constants/index";
+import { requestCapturePermission } from "../utils/permissions";
 
 const SummaryPage = () => {
   const { summaryStatus, setSummaryStatus, summaryData, setSummaryData } = useOutletContext();
 
   const handleSummaryClick = async () => {
+    const hasPermission = await requestCapturePermission();
+
+    if (!hasPermission) {
+      console.error("요약 실패: 화면 캡처 권한이 필요합니다.");
+
+      return;
+    }
+
     setSummaryStatus(SUMMARY_STATUS.LOADING);
 
-    const testItem = TEST_DATA.MUSINSA;
-    const response = await fetch(testItem.image);
-    const testItemImageBlob = await response.blob();
-    const imageBase64 = await blobToBase64(testItemImageBlob);
+    chrome.runtime.sendMessage({ type: "SUMMARIZE" }, (response) => {
+      if (response?.success) {
+        setSummaryData(response.data);
 
-    chrome.runtime.sendMessage(
-      {
-        type: "SUMMARIZE",
-        payload: {
-          url: testItem.url,
-          imageBase64: imageBase64,
-        },
-      },
-      (response) => {
-        if (response?.success) {
-          setSummaryData(response.data);
+        setSummaryStatus((currentStatus) => {
+          if (currentStatus !== SUMMARY_STATUS.LOADING) {
+            return currentStatus;
+          }
 
-          setSummaryStatus((currentStatus) => {
-            if (currentStatus !== SUMMARY_STATUS.LOADING) {
-              return currentStatus;
-            }
+          return SUMMARY_STATUS.RESULT;
+        });
+      } else {
+        console.error("요약 실패:", response?.error);
 
-            return SUMMARY_STATUS.RESULT;
-          });
-        } else {
-          console.error("요약 실패:", response?.error);
-
-          return SUMMARY_STATUS.DEFAULT;
-        }
-      },
-    );
+        setSummaryStatus(SUMMARY_STATUS.DEFAULT);
+      }
+    });
   };
 
   return (

--- a/src/utils/permissions.js
+++ b/src/utils/permissions.js
@@ -1,0 +1,8 @@
+export const requestCapturePermission = async () => {
+  const origins = ["<all_urls>"];
+  const hasPermission = await chrome.permissions.contains({ origins });
+
+  if (hasPermission) return true;
+
+  return await chrome.permissions.request({ origins });
+};


### PR DESCRIPTION
## 변경 내용
> #23 
- [x] manifest.json에 optional_host_permissions 추가
- [x] background.js에 captureVisibleTab 함수 추가
- [x] handleSummarizeMessage에서 직접 캡처 및 URL 획득
- [x] SummaryPage.jsx에서 테스트 데이터 제거 및 권한 요청 추가


## 기타 참고 사항
현재 요약은 chrome.tabs.captureVisibleTab을 사용하고 있어
캡처 결과가 뷰포트에 의존적입니다.
그래서 같은 페이지인데도 브라우저 배율, 창 크기에 따라 요약 결과의 품질 차이가 발생합니다.

### 한계점
#### 1. 화면 확대 시 캡처 정보 감소
사용자가 브라우저 화면을 확대(120% 이상)하여 사용하는 경우,
화면에 표시되는 콘텐츠 양이 줄어들어 캡처되는 정보가 부족했습니다.

예를 들어, 100% 배율에서는 기사 전체 제목과 본문 일부가 보이지만,
150% 배율에서는 제목만 보일 수 있습니다.
이 경우 LLM에서 분석할 수 있는 정보가 부족해져서 제대로 된 요약 결과를 얻을 수 없습니다.

#### 2. 작은 뷰포트에서의 정보 제한
브라우저 창 크기가 작은 경우에도 동일한 문제가 발생합니다.
캡처되는 영역이 좁아져 페이지 내용의 일부만 캡처되고,
이로 인해 전체 맥락을 파악하기 어려운 요약 결과가 나올 수 있습니다.

### 뷰포트에 따른 요약 결과 

#### 뷰포트가 작은버젼
<img width="1452" height="1202" alt="image" src="https://github.com/user-attachments/assets/af6988aa-172e-412d-a60c-32a3e63efc80" />

- 본문 정보가 제한됨

#### 뷰포트 전체 화면
<img width="505" height="951" alt="스크린샷 2026-01-14 오후 6 59 44" src="https://github.com/user-attachments/assets/c5b43b1a-80a6-441a-9648-ce44ce0bbd9f" />

- 제목 + 본문 일부가 함께 캡처되어, LLM이 페이지 맥락을 파악할 수 있음

### 향후 개선 방향
뷰포트가 너무 작거나 화면 배율이 높은 경우,
캡처 전에 사용자에게 안내 메시지를 표시하는 것을 고려할 수 있을 것 같습니다.

> 예: "화면 배율이 높아 요약 품질이 저하될 수 있습니다. 100%로 조정해 주세요."
