### PR TITLE
feat: 대시보드 사용자 설정 기능 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -65,6 +65,10 @@ const App = () => {
     chrome.storage.local.remove("token");
   };
 
+  const handleSettingsButtonClick = () => {
+    chrome.runtime.openOptionsPage();
+  };
+
   const handleFooterDeleteButton = () => {
     setIsModalOpen(true);
   };
@@ -138,6 +142,7 @@ const App = () => {
         onLogoClick={handleLogoClick}
         onLoginClick={handleLoginButtonClick}
         onLogoutClick={handleLogoutButtonClick}
+        onSettingsClick={handleSettingsButtonClick}
       />
       <main className="flex flex-col items-center gap-2 w-full h-full p-3 border border-sl-blue rounded-xl overflow-y-auto">
         <Outlet

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -25,9 +25,13 @@ const handleSummarizeMessage = async (sendResponse) => {
     const response = await fetch(imageBase64);
     const imageBlob = await response.blob();
 
+    const { settings } = await chrome.storage.sync.get("settings");
+    const userSettings = settings || { length: "medium", persona: "default" };
+
     const formData = new FormData();
     formData.append("url", url);
     formData.append("image", imageBlob, "screenshot.png");
+    formData.append("settings", JSON.stringify(userSettings));
 
     const data = await api.post("summaries", { body: formData }).json();
 
@@ -71,9 +75,12 @@ const handleAnalyzeImage = async (payload, sendResponse) => {
   const { imageUrl, pageUrl } = payload;
 
   try {
+    const { settings } = await chrome.storage.sync.get("settings");
+    const userSettings = settings || { length: "medium", persona: "default" };
+
     const data = await api
       .post("analyses", {
-        json: { imageUrl, pageUrl },
+        json: { imageUrl, pageUrl, settings: userSettings },
       })
       .json();
 

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -9,6 +9,7 @@ const Header = ({
   onLogoClick,
   onLoginClick,
   onLogoutClick,
+  onSettingsClick,
 }) => {
   const isLoading = summaryStatus === SUMMARY_STATUS.LOADING;
   const isHistoryPage = currentPath.startsWith("/history");
@@ -33,7 +34,7 @@ const Header = ({
               {isLoggedIn ? "로그아웃" : "로그인"}
             </Button>
           )}
-          <Button bgColor="bg-sl-white" borderColor="border-sl-blue">
+          <Button bgColor="bg-sl-white" borderColor="border-sl-blue" onClick={onSettingsClick}>
             설정
           </Button>
         </div>

--- a/src/components/SettingSelect.jsx
+++ b/src/components/SettingSelect.jsx
@@ -1,12 +1,19 @@
-const SettingSelect = ({ label, children }) => {
+const SettingSelect = ({ label, value, onChange, options }) => {
   return (
     <div className="mb-8">
       <label className="block mb-2 text-lg text-sl-gray-dark">{label}</label>
       <div className="relative">
-        <select className="w-full p-3 bg-sl-white border border-sl-gray-light rounded-lg text-lg">
-          {children}
+        <select
+          value={value}
+          onChange={onChange}
+          className="w-full p-3 bg-sl-white border border-sl-gray-light rounded-lg text-lg"
+        >
+          {options.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
         </select>
-        <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sl-gray-light pointer-events-none"></span>
       </div>
     </div>
   );

--- a/src/components/SettingSidebarLink.jsx
+++ b/src/components/SettingSidebarLink.jsx
@@ -1,9 +1,16 @@
-const SettingSidebarLink = ({ label, href = "#" }) => {
+import { NavLink } from "react-router";
+
+const SettingSidebarLink = ({ label, to }) => {
   return (
     <li>
-      <a href={href} className="block w-full px-8 py-4 text-left text-lg text-sl-black">
+      <NavLink
+        to={to}
+        className={({ isActive }) =>
+          `block w-full px-8 py-4 text-left text-lg ${isActive ? "bg-sl-blue text-white" : "text-sl-black"}`
+        }
+      >
         {label}
-      </a>
+      </NavLink>
     </li>
   );
 };

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -10,6 +10,23 @@ const IMAGE_ANALYSIS_STATUS = {
   ERROR: "error",
 };
 
+const LENGTH_OPTIONS = [
+  { value: "short", label: "짧게" },
+  { value: "medium", label: "중간" },
+  { value: "long", label: "길게" },
+];
+
+const PERSONA_OPTIONS = [
+  { value: "friendly", label: "친근함" },
+  { value: "default", label: "기본" },
+  { value: "professional", label: "전문적" },
+];
+
+const DEFAULT_SETTINGS = {
+  length: "medium",
+  persona: "default",
+};
+
 const TEST_DATA = {
   YONHAP_NEWS: {
     url: "https://www.yna.co.kr/view/AKR20231213165600007",
@@ -25,4 +42,11 @@ const TEST_DATA = {
   },
 };
 
-export { SUMMARY_STATUS, IMAGE_ANALYSIS_STATUS, TEST_DATA };
+export {
+  SUMMARY_STATUS,
+  IMAGE_ANALYSIS_STATUS,
+  LENGTH_OPTIONS,
+  PERSONA_OPTIONS,
+  DEFAULT_SETTINGS,
+  TEST_DATA,
+};

--- a/src/pages/GeneralPage.jsx
+++ b/src/pages/GeneralPage.jsx
@@ -6,15 +6,14 @@ const GeneralPage = () => {
   return (
     <SettingTabLayout title="일반">
       <SettingSelect label="요약 길이 조절">
-        <option value="짧게">짧게</option>
-        <option value="중간">중간</option>
-        <option value="길게">길게</option>
+        <option value="short">짧게</option>
+        <option value="medium">중간</option>
+        <option value="long">길게</option>
       </SettingSelect>
       <SettingSelect label="텍스트 페르소나">
-        <option value="일반 모드">일반 모드</option>
-        <option value="찐친 모드">찐친 모드</option>
-        <option value="초등학교 선생님 모드">초등학교 선생님 모드</option>
-        <option value="큐레이터 모드">큐레이터 모드</option>
+        <option value="friendly">친근함</option>
+        <option value="default">기본</option>
+        <option value="professional">전문적</option>
       </SettingSelect>
       <SettingLink label="단축키 설정" />
     </SettingTabLayout>

--- a/src/pages/GeneralPage.jsx
+++ b/src/pages/GeneralPage.jsx
@@ -1,21 +1,74 @@
+import { useState, useEffect } from "react";
 import SettingTabLayout from "../components/SettingTabLayout.jsx";
 import SettingSelect from "../components/SettingSelect.jsx";
 import SettingLink from "../components/SettingLink.jsx";
+import { LENGTH_OPTIONS, PERSONA_OPTIONS, DEFAULT_SETTINGS } from "../constants/index.js";
 
 const GeneralPage = () => {
+  const [length, setLength] = useState(DEFAULT_SETTINGS.length);
+  const [persona, setPersona] = useState(DEFAULT_SETTINGS.persona);
+  const [isSaved, setIsSaved] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    chrome.storage.sync.get("settings", (result) => {
+      if (!isMounted) return;
+
+      if (result.settings) {
+        setLength(result.settings.length || DEFAULT_SETTINGS.length);
+        setPersona(result.settings.persona || DEFAULT_SETTINGS.persona);
+      }
+    });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const handleLengthChange = (e) => {
+    setLength(e.target.value);
+    setIsSaved(false);
+  };
+
+  const handlePersonaChange = (e) => {
+    setPersona(e.target.value);
+    setIsSaved(false);
+  };
+
+  const handleSave = () => {
+    const settings = { length, persona };
+
+    chrome.storage.sync.set({ settings }, () => {
+      setIsSaved(true);
+    });
+  };
+
   return (
     <SettingTabLayout title="일반">
-      <SettingSelect label="요약 길이 조절">
-        <option value="short">짧게</option>
-        <option value="medium">중간</option>
-        <option value="long">길게</option>
-      </SettingSelect>
-      <SettingSelect label="텍스트 페르소나">
-        <option value="friendly">친근함</option>
-        <option value="default">기본</option>
-        <option value="professional">전문적</option>
-      </SettingSelect>
+      <SettingSelect
+        label="요약 길이 조절"
+        value={length}
+        onChange={handleLengthChange}
+        options={LENGTH_OPTIONS}
+      />
+      <SettingSelect
+        label="텍스트 페르소나"
+        value={persona}
+        onChange={handlePersonaChange}
+        options={PERSONA_OPTIONS}
+      />
       <SettingLink label="단축키 설정" />
+
+      <button
+        type="button"
+        onClick={handleSave}
+        className="w-full px-6 py-3 bg-sl-blue text-white rounded-lg text-lg"
+      >
+        저장
+      </button>
+
+      {isSaved && <p className="mt-4 text-sl-gray-dark text-base">설정이 저장되었습니다.</p>}
     </SettingTabLayout>
   );
 };

--- a/src/tabs/Settings.jsx
+++ b/src/tabs/Settings.jsx
@@ -1,30 +1,23 @@
+import { Outlet } from "react-router";
 import SettingSidebarLink from "../components/SettingSidebarLink.jsx";
-import GeneralPage from "../pages/GeneralPage.jsx";
-import AccessibilityPage from "../pages/AccessibilityPage.jsx";
-import InfoPage from "../pages/InfoPage.jsx";
+import Logo from "../components/Logo.jsx";
 
 const Settings = () => {
   return (
     <div className="flex min-h-screen bg-sl-white text-sl-black">
-      <aside className="flex flex-col w-72 border-r border-sl-gray-light">
-        <div className="flex items-center gap-3 p-8">
-          <img
-            src="/images/icons/spreadlove-icon-48.png"
-            alt="SpreadLove 로고"
-            className="w-10 h-10"
-          />
-          <span className="text-2xl font-bold">SpreadLove</span>
+      <aside className="flex flex-col w-75 border-r border-sl-gray-light">
+        <div className="mt-3 p-6">
+          <Logo iconSize={48} textSize={32} spacing="mt-0.5 ml-2 mb-3" />
         </div>
         <nav>
           <ul>
-            <SettingSidebarLink label="일반" />
-            <SettingSidebarLink label="저시력자 모드" />
-            <SettingSidebarLink label="정보" />
+            <SettingSidebarLink label="일반" to="/general" />
+            <SettingSidebarLink label="정보" to="/info" />
           </ul>
         </nav>
       </aside>
       <main className="flex-1 p-8">
-        <GeneralPage />
+        <Outlet />
       </main>
     </div>
   );

--- a/src/tabs/main.jsx
+++ b/src/tabs/main.jsx
@@ -1,10 +1,11 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { RouterProvider } from "react-router";
 import "../styles/globals.css";
-import Settings from "./Settings.jsx";
+import { settingsRouter } from "./settingsRouter.jsx";
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
-    <Settings />
+    <RouterProvider router={settingsRouter} />
   </StrictMode>,
 );

--- a/src/tabs/settingsRouter.jsx
+++ b/src/tabs/settingsRouter.jsx
@@ -1,0 +1,16 @@
+import { createHashRouter, Navigate } from "react-router";
+import Settings from "./Settings.jsx";
+import GeneralPage from "../pages/GeneralPage.jsx";
+import InfoPage from "../pages/InfoPage.jsx";
+
+export const settingsRouter = createHashRouter([
+  {
+    path: "/",
+    element: <Settings />,
+    children: [
+      { index: true, element: <Navigate to="/general" replace /> },
+      { path: "general", element: <GeneralPage /> },
+      { path: "info", element: <InfoPage /> },
+    ],
+  },
+]);


### PR DESCRIPTION
## 변경 내용
> #27
- [x]  설정 버튼 클릭 시 옵션 페이지 열기 구현
- [x]  설정 페이지에 HashRouter 적용 (일반/정보 탭 전환)
- [x]  요약 길이 설정 UI 구현 (짧게/중간/길게)
- [x] 텍스트 페르소나 설정 UI 구현 (친근함/기본/전문적)
- [x] 설정값 chrome.storage.sync에 저장/불러오기
- [x] 저장 완료 피드백 메시지 표시
- [x] 요약/분석 요청 시 설정값 서버로 전달

## 기타 참고 사항

```json
{
  "settings": {
    "length": "short | medium | long",
    "persona": "friendly | default | professional"
  }
}
```

### 기본값
사용자가 설정 페이지에서 저장하지 않은 경우, 다음 기본값이 서버로 전달됩니다:
- length: "medium"
- persona: "default"

#### 서버 연동 참고
현재 프론트엔드에서 settings를 전달하고 있지만, 서버에서 해당 값을 활용하는 로직은 별도 작업이 필요합니다.
- 요약 요청: formData.append("settings", JSON.stringify(userSettings))
- 분석 요청: json: { imageUrl, pageUrl, settings: userSettings }
서버에서 req.body.settings를 파싱하여 AI 프롬프트에 반영해야 합니다.


