### PR TITLE
feat: 사용자 식별 헤더 전송 및 일일 API 사용량 한도 초과 처리

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,7 @@ import { Outlet, useLocation, useNavigate, matchPath } from "react-router";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 import DeleteModal from "./components/DeleteModal";
-import { SUMMARY_STATUS, IMAGE_ANALYSIS_STATUS } from "./constants/index.js";
+import { SUMMARY_STATUS, IMAGE_ANALYSIS_STATUS, ERROR_MESSAGES } from "./constants/index.js";
 
 const App = () => {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
@@ -104,6 +104,11 @@ const App = () => {
     const handleStorageChange = (changes) => {
       if (changes.token && isMounted) {
         setIsLoggedIn(Boolean(changes.token.newValue));
+      }
+
+      if (changes.rateLimitExceeded && changes.rateLimitExceeded.newValue === true && isMounted) {
+        alert(ERROR_MESSAGES.RATE_LIMIT_EXCEEDED);
+        chrome.storage.local.remove("rateLimitExceeded");
       }
     };
 

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -33,6 +33,13 @@ const api = ky.create({
         }
       },
     ],
+    afterResponse: [
+      async (request, options, response) => {
+        if (response.status === 429) {
+          await chrome.storage.local.set({ rateLimitExceeded: true });
+        }
+      },
+    ],
   },
 });
 

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,5 +1,17 @@
 import ky from "ky";
 
+const getOrCreateGuestId = async () => {
+  const result = await chrome.storage.local.get("guestId");
+
+  if (result.guestId) {
+    return result.guestId;
+  }
+
+  const guestId = crypto.randomUUID();
+  await chrome.storage.local.set({ guestId });
+  return guestId;
+};
+
 const api = ky.create({
   prefixUrl: import.meta.env.VITE_API_BASE_URL,
   timeout: 30000,
@@ -9,11 +21,15 @@ const api = ky.create({
         try {
           const result = await chrome.storage.local.get("token");
           const token = result.token;
+
           if (token) {
             request.headers.set("Authorization", `Bearer ${token}`);
+          } else {
+            const guestId = await getOrCreateGuestId();
+            request.headers.set("Guest-Id", guestId);
           }
         } catch (error) {
-          console.error("토큰 로드 실패:", error);
+          console.error("헤더 설정 실패:", error);
         }
       },
     ],

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -10,6 +10,10 @@ const IMAGE_ANALYSIS_STATUS = {
   ERROR: "error",
 };
 
+const ERROR_MESSAGES = {
+  RATE_LIMIT_EXCEEDED: "일일 사용 횟수를 초과했습니다.",
+};
+
 const LENGTH_OPTIONS = [
   { value: "short", label: "짧게" },
   { value: "medium", label: "중간" },
@@ -45,6 +49,7 @@ const TEST_DATA = {
 export {
   SUMMARY_STATUS,
   IMAGE_ANALYSIS_STATUS,
+  ERROR_MESSAGES,
   LENGTH_OPTIONS,
   PERSONA_OPTIONS,
   DEFAULT_SETTINGS,


### PR DESCRIPTION
## 변경 내용
> #25 

- [x] 비회원 Guest-Id 생성 및 `chrome.storage.local`에 저장
- [x] 로그인 상태에 따라 `Authorization` / `Guest-Id` 헤더 분기 처리
- [x] 429 에러 발생 시 `rateLimitExceeded` 플래그 저장
- [x] `chrome.storage.onChanged` 리스너로 플래그 감지 후 alert 표시

### 1. 비회원 Guest-Id 생성 및 API 요청 헤더 분기 처리

#### 변경 파일

- `src/api/client.js`

#### 내용

- `getOrCreateGuestId()` 함수 추가: `crypto.randomUUID()`로 Guest-Id 생성 후 `chrome.storage.local`에 저장
- `beforeRequest` 훅에서 로그인 상태에 따라 헤더 분기:
  - **로그인**: `Authorization: Bearer [token]` 헤더 전송
  - **비로그인**: `Guest-Id: [UUID]` 헤더 전송

### 2. 429 에러 발생 시 일일 사용 횟수 초과 알림 표시

#### 변경 파일

- `src/api/client.js`
- `src/App.jsx`
- `src/constants/index.js`

#### 내용

- `afterResponse` 훅에서 429 상태코드 감지 시 `rateLimitExceeded: true` 플래그 저장
- `App.jsx`에서 `chrome.storage.onChanged` 리스너로 플래그 감지
- 플래그가 `true`일 때 `alert("일일 사용 횟수를 초과했습니다.")` 표시 후 플래그 삭제


## 기타 참고 사항

### 1. alert() 사용 결정 배경

모달 컴포넌트 대신 `alert()`를 사용한 이유:

- 429 에러임
- 구현이 상대적으로 간단함
- 추후 모달로 리팩토링 예정

### 2. alert() 구현 시 발생한 문제

**문제**: API 클라이언트(`client.js`)의 `afterResponse` 훅에서 직접 `alert()`를 호출하려고 했으나, **Service Worker에서는 `alert()` 사용이 불가능**

**원인**: `client.js`는 `background.js`(Service Worker)에서 실행되며, Service Worker는 DOM과 분리된 환경이므로 `alert()` 사용 불가

**해결**: Storage 플래그 방식 도입

```
client.js (Service Worker) → chrome.storage → App.jsx (React UI)
429 에러 발생                  플래그 저장        변경 감지 → alert() 표시
```

### 3. 테스트 방법

#### 테스트 1: Guest-Id 생성 및 헤더 전송

<준비>

1. `chrome://extensions` → Service Worker 클릭
2. Console에서 `chrome.storage.local.clear()` 실행
3. 백엔드 Redis 캐시 초기화: `redis-cli FLUSHALL`

<테스트>

1. 확장 프로그램에서 "이 페이지 요약하기" 클릭
2. DevTools > Network > Request Headers 확인
3. `Guest-Id: [UUID]` 헤더 포함 확인

#### 테스트 2: 429 에러 alert 표시

<테스트>

1. 비회원 상태로 "이 페이지 요약하기" 4번 클릭
2. 4번째에 `alert("일일 사용 횟수를 초과했습니다.")` 표시 확인

#### 테스트 결과

| 테스트             | 결과    |
| ------------------ | ------- |
| Guest-Id 생성      | ✅ 성공 |
| Guest-Id 헤더 전송 | ✅ 성공 |
| 429 에러 감지      | ✅ 성공 |
| alert 표시         | ✅ 성공 |

### 4. 남은 횟수 UI 표시 기능 별도 이슈 분리 예정

- 남은 횟수 UI 표시 기능은 백엔드 API(`GET /rate-limit`)가 필요하여 별도 이슈로 분리하여 작업 예정입니다.
- 현재 로그인 시 프론트엔드 ↔ Supabase 간 직접 통신하므로 백엔드를 거치지 않아 Rate Limit 정보를 조회할 수 없습니다.
- 그래서 로그인 시 사용자의 정확한 잔여 횟수를 조회하려면 백엔드에서 Redis Rate Limit 정보를 반환하는 API가 필요하기 때문입니다.