### PR TITLE
refactor: 페이지 캡처 방식 및 이미지 해석 방식 변경

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -37,8 +37,7 @@
       "js": ["src/content/content.js"]
     }
   ],
-  "permissions": ["sidePanel", "storage", "activeTab"],
-  "optional_host_permissions": ["<all_urls>"],
+  "permissions": ["sidePanel", "storage", "activeTab", "tabs"],
   "host_permissions": ["http://localhost:3000/*"],
   "options_page": "src/tabs/settings.html"
 }

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -3,37 +3,19 @@ import { api } from "../api/client.js";
 const sidePanelConfig = { openPanelOnActionClick: true };
 const focusedImages = new Map();
 
-const captureVisibleTab = () => {
-  return new Promise((resolve, reject) => {
-    chrome.tabs.captureVisibleTab(null, { format: "png" }, (dataUrl) => {
-      if (chrome.runtime.lastError) {
-        reject(new Error(chrome.runtime.lastError.message));
-
-        return;
-      }
-      resolve(dataUrl);
-    });
-  });
-};
-
 const handleSummarizeMessage = async (sendResponse) => {
   try {
     const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true });
     const url = activeTab.url;
 
-    const imageBase64 = await captureVisibleTab();
-    const response = await fetch(imageBase64);
-    const imageBlob = await response.blob();
-
     const { settings } = await chrome.storage.sync.get("settings");
     const userSettings = settings || { length: "medium", persona: "default" };
 
-    const formData = new FormData();
-    formData.append("url", url);
-    formData.append("image", imageBlob, "screenshot.png");
-    formData.append("settings", JSON.stringify(userSettings));
-
-    const data = await api.post("summaries", { body: formData }).json();
+    const data = await api
+      .post("summaries", {
+        json: { url, settings: userSettings },
+      })
+      .json();
 
     sendResponse(data);
   } catch (error) {

--- a/src/content/content.js
+++ b/src/content/content.js
@@ -5,10 +5,6 @@ const handleFocusIn = (event) => {
 
   if (!imageElement) return;
 
-  const hasAlt = imageElement.alt && imageElement.alt.trim();
-
-  if (hasAlt) return;
-
   chrome.runtime.sendMessage({
     type: "IMAGE_FOCUSED",
     imageUrl: imageElement.currentSrc || imageElement.src,
@@ -25,9 +21,8 @@ const handleGetFocusedImage = (message, sender, sendResponse) => {
 
   const focusedElement = document.activeElement;
   const isImage = focusedElement && focusedElement.tagName === "IMG";
-  const hasAlt = focusedElement && focusedElement.alt && focusedElement.alt.trim();
 
-  if (!isImage || hasAlt) return sendResponse({ hasImage: false });
+  if (!isImage) return sendResponse({ hasImage: false });
 
   sendResponse({
     hasImage: true,

--- a/src/pages/SummaryPage.jsx
+++ b/src/pages/SummaryPage.jsx
@@ -1,20 +1,11 @@
 import { useOutletContext } from "react-router";
 import LoadingSpinner from "../components/LoadingSpinner";
 import { SUMMARY_STATUS } from "../constants/index";
-import { requestCapturePermission } from "../utils/permissions";
 
 const SummaryPage = () => {
   const { summaryStatus, setSummaryStatus, summaryData, setSummaryData } = useOutletContext();
 
   const handleSummaryClick = async () => {
-    const hasPermission = await requestCapturePermission();
-
-    if (!hasPermission) {
-      console.error("요약 실패: 화면 캡처 권한이 필요합니다.");
-
-      return;
-    }
-
     setSummaryStatus(SUMMARY_STATUS.LOADING);
 
     chrome.runtime.sendMessage({ type: "SUMMARIZE" }, (response) => {

--- a/src/utils/permissions.js
+++ b/src/utils/permissions.js
@@ -1,8 +1,0 @@
-export const requestCapturePermission = async () => {
-  const origins = ["<all_urls>"];
-  const hasPermission = await chrome.permissions.contains({ origins });
-
-  if (hasPermission) return true;
-
-  return await chrome.permissions.request({ origins });
-};


### PR DESCRIPTION
## 변경 내용

> #30

- [x] background.js: 요약 API 호출 방식을 JSON으로 변경
- [x] background.js: captureVisibleTab 함수 제거
- [x] SummaryPage.jsx: 권한 요청 로직 제거
- [x] permissions.js 파일 삭제
- [x] manifest.json: optional_host_permissions 제거, tabs 권한 추가
- [x] content.js: 이미지 분석 대상 확대 (모든 img 태그)


## 기타 참고 사항
### 테스트
백엔드 연동 후 전체 응답 시간을 테스트해 봤습니다.
테스트 결과, 페이지 복잡도에 따라 전체 응답 시간은  7~15초 정도로 예상됩니다.
로딩 UI로 대기중입니다를 안내하고 있어 사용자 경험에 문제가 없을 것으로 판단됩니다.

#### 네이버 메인 
<img width="533" height="133" alt="image" src="https://github.com/user-attachments/assets/dcb146fa-487d-43ac-85e5-f5de458a6997" />

- Total: ~3초
- OpenAI API: ~4초
- 전체 응답: 7초

#### 네이버 스포츠

<img width="370" height="134" alt="image" src="https://github.com/user-attachments/assets/fb4187a5-ed42-4f3b-ae4c-1f768c2ac438" />

- Total: ~3초
- OpenAI API: ~7초
- 전체 응답: 10초

### 권한 구조 변경

**변경 전:**
- `optional_host_permissions: ["<all_urls>"]` 사용 (captureVisibleTab용)
- 사용자에게 권한 요청 팝업 표시

**변경 후:**
- `tabs` 권한 사용 (URL 조회용)
- 권한 요청 없이 바로 요약 가능

### API 요청 형식 변경
기존 FormData 방식에서 JSON 방식으로 변경했습니다.
이제 이미지 파일 대신 URL만 담아서 전송합니다.

### 이미지 분석 대상 확대
기존에는 alt 속성이 없는 이미지만 분석 대상이었습니다.
이제는 alt 유무와 관계없이 모든 img 태그를 분석할 수 있습니다.

