### PR TITLE
refactor: 전역 상태 관리 구조 개선

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "ky": "^1.14.2",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
-        "react-router": "^7.11.0"
+        "react-router": "^7.11.0",
+        "zustand": "^5.0.10"
       },
       "devDependencies": {
         "@crxjs/vite-plugin": "^2.3.0",
@@ -65,7 +66,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1921,9 +1921,8 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1981,7 +1980,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2149,7 +2147,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2402,7 +2399,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2645,7 +2642,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4068,7 +4064,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4180,7 +4175,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4190,7 +4184,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4668,7 +4661,6 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4900,7 +4892,6 @@
       "integrity": "sha512-Zw/uYiiyF6pUT1qmKbZziChgNPRu+ZRneAsMUDU6IwmXdWt5JwcUfy2bvLOCUtz5UniaN/Zx5aFttZYbYc7O/A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -4916,6 +4907,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.10.tgz",
+      "integrity": "sha512-U1AiltS1O9hSy3rul+Ub82ut2fqIAefiSuwECWt6jlMVUGejvf+5omLcRBSzqbRagSM3hQZbtzdeRc6QVScXTg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "ky": "^1.14.2",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-router": "^7.11.0"
+    "react-router": "^7.11.0",
+    "zustand": "^5.0.10"
   },
   "devDependencies": {
     "@crxjs/vite-plugin": "^2.3.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,96 +1,15 @@
-import { useEffect, useState } from "react";
-import { Outlet, useLocation, useNavigate, matchPath } from "react-router";
+import { useEffect } from "react";
+import { Outlet, useLocation, useNavigate } from "react-router";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 import DeleteModal from "./components/DeleteModal";
-import { SUMMARY_STATUS, IMAGE_ANALYSIS_STATUS, ERROR_MESSAGES } from "./constants/index.js";
+import { ERROR_MESSAGES } from "./constants/index.js";
+import useAuthStore from "./stores/useAuthStore";
 
 const App = () => {
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
-  const [summaryStatus, setSummaryStatus] = useState(SUMMARY_STATUS.DEFAULT);
-  const [summaryData, setSummaryData] = useState(null);
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [analysisStatus, setAnalysisStatus] = useState(IMAGE_ANALYSIS_STATUS.LOADING);
-  const [analysisData, setAnalysisData] = useState(null);
-
   const location = useLocation();
   const navigate = useNavigate();
-
-  const getHistoryId = () => {
-    if (location.pathname === "/") {
-      return summaryData.historyId;
-    }
-
-    if (location.pathname.startsWith("/history/")) {
-      const match = matchPath("/history/:id", location.pathname);
-      return match.params.id;
-    }
-
-    if (location.pathname === "/analysis") {
-      return analysisData?.data?.historyId;
-    }
-
-    return null;
-  };
-
-  const afterDeleteAction = () => {
-    setIsModalOpen(false);
-
-    if (location.pathname === "/") {
-      setSummaryStatus(SUMMARY_STATUS.DEFAULT);
-      setSummaryData(null);
-    }
-
-    if (location.pathname.startsWith("/history/")) {
-      navigate("/history");
-    }
-
-    if (location.pathname === "/analysis") {
-      setAnalysisStatus(IMAGE_ANALYSIS_STATUS.LOADING);
-      setAnalysisData(null);
-      navigate("/");
-    }
-  };
-
-  const handleLogoClick = () => {
-    setSummaryStatus(SUMMARY_STATUS.DEFAULT);
-  };
-
-  const handleLoginButtonClick = () => {
-    const loginUrl = chrome.runtime.getURL("src/tabs/login.html");
-    chrome.tabs.create({ url: loginUrl });
-  };
-
-  const handleLogoutButtonClick = () => {
-    chrome.storage.local.remove("token");
-  };
-
-  const handleSettingsButtonClick = () => {
-    chrome.runtime.openOptionsPage();
-  };
-
-  const handleFooterDeleteButton = () => {
-    setIsModalOpen(true);
-  };
-
-  const handleModalCancelButton = () => {
-    setIsModalOpen(false);
-  };
-
-  const handleModalDeleteButton = () => {
-    const historyId = getHistoryId();
-    chrome.runtime.sendMessage(
-      {
-        type: "DELETE_HISTORY",
-        payload: { historyId },
-      },
-      (response) => {
-        if (!response.success) return;
-
-        afterDeleteAction();
-      },
-    );
-  };
+  const { setIsLoggedIn } = useAuthStore();
 
   useEffect(() => {
     let isMounted = true;
@@ -140,41 +59,12 @@ const App = () => {
 
   return (
     <div className="flex flex-col h-screen gap-5 p-5">
-      <Header
-        isLoggedIn={isLoggedIn}
-        summaryStatus={summaryStatus}
-        currentPath={location.pathname}
-        onLogoClick={handleLogoClick}
-        onLoginClick={handleLoginButtonClick}
-        onLogoutClick={handleLogoutButtonClick}
-        onSettingsClick={handleSettingsButtonClick}
-      />
+      <Header currentPath={location.pathname} />
       <main className="flex flex-col items-center gap-2 w-full h-full p-3 border border-sl-blue rounded-xl overflow-y-auto">
-        <Outlet
-          context={{
-            summaryStatus,
-            setSummaryStatus,
-            summaryData,
-            setSummaryData,
-            analysisStatus,
-            setAnalysisStatus,
-            analysisData,
-            setAnalysisData,
-          }}
-        />
+        <Outlet />
       </main>
-      <Footer
-        isLoggedIn={isLoggedIn}
-        currentPath={location.pathname}
-        summaryStatus={summaryStatus}
-        analysisStatus={analysisStatus}
-        onDeleteClick={handleFooterDeleteButton}
-      />
-      <DeleteModal
-        isOpen={isModalOpen}
-        onCancel={handleModalCancelButton}
-        onDelete={handleModalDeleteButton}
-      />
+      <Footer currentPath={location.pathname} />
+      <DeleteModal />
     </div>
   );
 };

--- a/src/components/DeleteModal.jsx
+++ b/src/components/DeleteModal.jsx
@@ -1,7 +1,62 @@
+import { useLocation, useNavigate, matchPath } from "react-router";
 import Button from "./Button";
+import useModalStore from "../stores/useModalStore";
+import useResultStore from "../stores/useResultStore";
 
-const DeleteModal = ({ isOpen, onCancel, onDelete }) => {
-  if (!isOpen) return null;
+const DeleteModal = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const { isModalOpen, closeModal } = useModalStore();
+  const { summaryData, analysisData, resetSummary, resetAnalysis } = useResultStore();
+
+  if (!isModalOpen) return null;
+
+  const getHistoryId = () => {
+    if (location.pathname === "/") {
+      return summaryData?.historyId;
+    }
+
+    if (location.pathname.startsWith("/history/")) {
+      const match = matchPath("/history/:id", location.pathname);
+      return match.params.id;
+    }
+
+    if (location.pathname === "/analysis") {
+      return analysisData?.data?.historyId;
+    }
+
+    return null;
+  };
+
+  const handleDelete = () => {
+    const historyId = getHistoryId();
+
+    chrome.runtime.sendMessage(
+      {
+        type: "DELETE_HISTORY",
+        payload: { historyId },
+      },
+      (response) => {
+        if (!response.success) return;
+
+        closeModal();
+
+        if (location.pathname === "/") {
+          resetSummary();
+        }
+
+        if (location.pathname.startsWith("/history/")) {
+          navigate("/history");
+        }
+
+        if (location.pathname === "/analysis") {
+          resetAnalysis();
+          navigate("/");
+        }
+      },
+    );
+  };
 
   return (
     <div className="fixed inset-0 z-10 flex items-end justify-center">
@@ -12,14 +67,14 @@ const DeleteModal = ({ isOpen, onCancel, onDelete }) => {
           이 채팅을 삭제하시겠습니까? 이 작업은 취소할 수 없습니다.
         </p>
         <div className="flex justify-end gap-3">
-          <Button bgColor="bg-sl-white" borderColor="border-sl-blue" onClick={onCancel}>
+          <Button bgColor="bg-sl-white" borderColor="border-sl-blue" onClick={closeModal}>
             취소
           </Button>
           <Button
             bgColor="bg-sl-red"
             borderColor="border-sl-red"
             textColor="text-sl-white"
-            onClick={onDelete}
+            onClick={handleDelete}
           >
             삭제
           </Button>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,22 +1,27 @@
 import Button from "./Button";
 import { SUMMARY_STATUS, IMAGE_ANALYSIS_STATUS } from "../constants/index.js";
+import useAuthStore from "../stores/useAuthStore";
+import useResultStore from "../stores/useResultStore";
+import useModalStore from "../stores/useModalStore";
 
-const Footer = ({ isLoggedIn, currentPath, summaryStatus, analysisStatus, onDeleteClick }) => {
+const Footer = ({ currentPath }) => {
+  const { isLoggedIn } = useAuthStore();
+  const { summaryStatus, analysisStatus } = useResultStore();
+  const { openModal } = useModalStore();
+
   const isLoading = summaryStatus === SUMMARY_STATUS.LOADING;
   const isResult = summaryStatus === SUMMARY_STATUS.RESULT;
+  const isAnalysisResult = analysisStatus === IMAGE_ANALYSIS_STATUS.RESULT;
 
   const isSummaryPage = currentPath === "/";
   const isHistoryDetailPage = currentPath.startsWith("/history/");
-
   const isAnalysisPage = currentPath === "/analysis";
-  const isAnalysisResult = analysisStatus === IMAGE_ANALYSIS_STATUS.RESULT;
-  const isSaveButtonVisible =
-    !isLoading &&
-    ((isSummaryPage && isResult) || isHistoryDetailPage || (isAnalysisPage && isAnalysisResult));
-  const isDeleteButtonVisible =
-    !isLoading &&
-    isLoggedIn &&
-    ((isSummaryPage && isResult) || isHistoryDetailPage || (isAnalysisPage && isAnalysisResult));
+
+  const hasResult =
+    (isSummaryPage && isResult) || isHistoryDetailPage || (isAnalysisPage && isAnalysisResult);
+
+  const isSaveButtonVisible = !isLoading && hasResult;
+  const isDeleteButtonVisible = !isLoading && isLoggedIn && hasResult;
 
   return (
     <footer className="flex justify-end gap-x-2">
@@ -26,7 +31,7 @@ const Footer = ({ isLoggedIn, currentPath, summaryStatus, analysisStatus, onDele
         </Button>
       )}
       {isDeleteButtonVisible && (
-        <Button bgColor="bg-sl-white" borderColor="border-sl-blue" onClick={onDeleteClick}>
+        <Button bgColor="bg-sl-white" borderColor="border-sl-blue" onClick={openModal}>
           삭제
         </Button>
       )}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,24 +1,39 @@
 import Logo from "./Logo";
 import Button from "./Button";
 import { SUMMARY_STATUS } from "../constants/index.js";
+import useAuthStore from "../stores/useAuthStore";
+import useResultStore from "../stores/useResultStore";
 
-const Header = ({
-  isLoggedIn,
-  summaryStatus,
-  currentPath,
-  onLogoClick,
-  onLoginClick,
-  onLogoutClick,
-  onSettingsClick,
-}) => {
+const Header = ({ currentPath }) => {
+  const { isLoggedIn } = useAuthStore();
+  const { summaryStatus, resetSummary, resetAnalysis } = useResultStore();
+
   const isLoading = summaryStatus === SUMMARY_STATUS.LOADING;
   const isHistoryPage = currentPath.startsWith("/history");
   const isHistoryButtonVisible = !isLoading && isLoggedIn && !isHistoryPage;
 
+  const handleLogoClick = () => {
+    resetSummary();
+    resetAnalysis();
+  };
+
+  const handleLoginClick = () => {
+    const loginUrl = chrome.runtime.getURL("src/tabs/login.html");
+    chrome.tabs.create({ url: loginUrl });
+  };
+
+  const handleLogoutClick = () => {
+    chrome.storage.local.remove("token");
+  };
+
+  const handleSettingsClick = () => {
+    chrome.runtime.openOptionsPage();
+  };
+
   return (
     <header>
       <div className="flex justify-between">
-        <Logo iconSize={32} textSize={16} spacing="mt-0.5 ml-1" onClick={onLogoClick} />
+        <Logo iconSize={32} textSize={16} spacing="mt-0.5 ml-1" onClick={handleLogoClick} />
         <div className="flex gap-x-2">
           {isHistoryButtonVisible && (
             <Button to="/history" bgColor="bg-sl-white" borderColor="border-sl-blue">
@@ -29,12 +44,12 @@ const Header = ({
             <Button
               bgColor="bg-sl-white"
               borderColor="border-sl-blue"
-              onClick={isLoggedIn ? onLogoutClick : onLoginClick}
+              onClick={isLoggedIn ? handleLogoutClick : handleLoginClick}
             >
               {isLoggedIn ? "로그아웃" : "로그인"}
             </Button>
           )}
-          <Button bgColor="bg-sl-white" borderColor="border-sl-blue" onClick={onSettingsClick}>
+          <Button bgColor="bg-sl-white" borderColor="border-sl-blue" onClick={handleSettingsClick}>
             설정
           </Button>
         </div>

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -2,6 +2,7 @@ const SUMMARY_STATUS = {
   DEFAULT: "default",
   LOADING: "loading",
   RESULT: "result",
+  ERROR: "error",
 };
 
 const IMAGE_ANALYSIS_STATUS = {

--- a/src/pages/ImageAnalysisPage.jsx
+++ b/src/pages/ImageAnalysisPage.jsx
@@ -1,11 +1,11 @@
 import { useState, useEffect } from "react";
-import { useOutletContext } from "react-router";
 import LoadingSpinner from "../components/LoadingSpinner";
 import { IMAGE_ANALYSIS_STATUS } from "../constants/index";
+import useResultStore from "../stores/useResultStore";
 
 const ImageAnalysisPage = () => {
-  const { analysisStatus, setAnalysisStatus, analysisData, setAnalysisData } = useOutletContext();
-  const [error, setError] = useState(null);
+  const { analysisStatus, analysisData, setAnalysisResult, setAnalysisError } = useResultStore();
+  const [errorMessage, setErrorMessage] = useState(null);
 
   useEffect(() => {
     let isActive = true;
@@ -13,11 +13,13 @@ const ImageAnalysisPage = () => {
     const analyzeImage = async () => {
       const { pendingImageAnalysis } = await chrome.storage.local.get("pendingImageAnalysis");
 
+      await chrome.storage.local.remove("pendingImageAnalysis");
+
       if (!isActive) return;
 
       if (!pendingImageAnalysis) {
-        setError("분석할 이미지 정보가 없습니다");
-        setAnalysisStatus(IMAGE_ANALYSIS_STATUS.ERROR);
+        setErrorMessage("분석할 이미지 정보가 없습니다");
+        setAnalysisError();
 
         return;
       }
@@ -36,12 +38,10 @@ const ImageAnalysisPage = () => {
           chrome.storage.local.remove("pendingImageAnalysis");
 
           if (response && response.success) {
-            console.log("[Spread Love] 분석 결과:", response.data);
-            setAnalysisData(response.data);
-            setAnalysisStatus(IMAGE_ANALYSIS_STATUS.RESULT);
+            setAnalysisResult(response.data);
           } else {
-            setError(response?.error || "이미지 분석에 실패했습니다");
-            setAnalysisStatus(IMAGE_ANALYSIS_STATUS.ERROR);
+            setErrorMessage(response?.error || "이미지 분석에 실패했습니다");
+            setAnalysisError();
           }
         },
       );
@@ -53,6 +53,7 @@ const ImageAnalysisPage = () => {
       isActive = false;
     };
   }, []);
+
   return (
     <div className="flex flex-col items-center justify-center w-full h-full">
       {analysisStatus === IMAGE_ANALYSIS_STATUS.LOADING && (
@@ -69,7 +70,7 @@ const ImageAnalysisPage = () => {
       {analysisStatus === IMAGE_ANALYSIS_STATUS.ERROR && (
         <div className="flex flex-col gap-4">
           <h1 className="text-[32px] font-bold text-sl-red">오류</h1>
-          <p className="text-xl">{error}</p>
+          <p className="text-xl">{errorMessage}</p>
         </div>
       )}
     </div>

--- a/src/pages/SummaryPage.jsx
+++ b/src/pages/SummaryPage.jsx
@@ -1,28 +1,20 @@
-import { useOutletContext } from "react-router";
 import LoadingSpinner from "../components/LoadingSpinner";
 import { SUMMARY_STATUS } from "../constants/index";
+import useResultStore from "../stores/useResultStore";
 
 const SummaryPage = () => {
-  const { summaryStatus, setSummaryStatus, summaryData, setSummaryData } = useOutletContext();
+  const { summaryStatus, summaryData, setSummaryLoading, setSummaryResult, resetSummary } =
+    useResultStore();
 
   const handleSummaryClick = async () => {
-    setSummaryStatus(SUMMARY_STATUS.LOADING);
+    setSummaryLoading();
 
     chrome.runtime.sendMessage({ type: "SUMMARIZE" }, (response) => {
       if (response?.success) {
-        setSummaryData(response.data);
-
-        setSummaryStatus((currentStatus) => {
-          if (currentStatus !== SUMMARY_STATUS.LOADING) {
-            return currentStatus;
-          }
-
-          return SUMMARY_STATUS.RESULT;
-        });
+        setSummaryResult(response.data);
       } else {
         console.error("요약 실패:", response?.error);
-
-        setSummaryStatus(SUMMARY_STATUS.DEFAULT);
+        resetSummary();
       }
     });
   };
@@ -51,4 +43,5 @@ const SummaryPage = () => {
     </div>
   );
 };
+
 export default SummaryPage;

--- a/src/stores/useAuthStore.js
+++ b/src/stores/useAuthStore.js
@@ -1,0 +1,9 @@
+import { create } from "zustand";
+
+const useAuthStore = create((set) => ({
+  isLoggedIn: false,
+
+  setIsLoggedIn: (value) => set({ isLoggedIn: value }),
+}));
+
+export default useAuthStore;

--- a/src/stores/useModalStore.js
+++ b/src/stores/useModalStore.js
@@ -1,0 +1,10 @@
+import { create } from "zustand";
+
+const useModalStore = create((set) => ({
+  isModalOpen: false,
+
+  openModal: () => set({ isModalOpen: true }),
+  closeModal: () => set({ isModalOpen: false }),
+}));
+
+export default useModalStore;

--- a/src/stores/useResultStore.js
+++ b/src/stores/useResultStore.js
@@ -1,0 +1,29 @@
+import { create } from "zustand";
+import { SUMMARY_STATUS, IMAGE_ANALYSIS_STATUS } from "../constants/index";
+
+const useResultStore = create((set) => ({
+  summaryStatus: SUMMARY_STATUS.DEFAULT,
+  summaryData: null,
+
+  analysisStatus: IMAGE_ANALYSIS_STATUS.LOADING,
+  analysisData: null,
+
+  setSummaryLoading: () => set({ summaryStatus: SUMMARY_STATUS.LOADING }),
+  setSummaryResult: (data) =>
+    set((state) => {
+      if (state.summaryStatus !== SUMMARY_STATUS.LOADING) {
+        return state;
+      }
+
+      return { summaryData: data, summaryStatus: SUMMARY_STATUS.RESULT };
+    }),
+  setSummaryError: () => set({ summaryStatus: SUMMARY_STATUS.ERROR }),
+  resetSummary: () => set({ summaryStatus: SUMMARY_STATUS.DEFAULT, summaryData: null }),
+
+  setAnalysisResult: (data) =>
+    set({ analysisData: data, analysisStatus: IMAGE_ANALYSIS_STATUS.RESULT }),
+  setAnalysisError: () => set({ analysisStatus: IMAGE_ANALYSIS_STATUS.ERROR }),
+  resetAnalysis: () => set({ analysisStatus: IMAGE_ANALYSIS_STATUS.LOADING, analysisData: null }),
+}));
+
+export default useResultStore;


### PR DESCRIPTION
## 변경 내용
> #33 
- [x]  Zustand 스토어 생성
- [x] 핸들러 함수들 각 컴포넌트로 이동
- [x] 컴포넌트 마이그레이션
- [x] 이미지 분석 중 패널 닫았다가 다시 열 때 분석이 되던 버그 해결

## 기타 참고 사항

### 왜 Zustand를 선택했나?
기존에는 `App.jsx`에서 `useState`로 상태를 관리하고 `useOutletContext`로 하위 컴포넌트에 전달하는 방식을 사용했습니다. 이 방식은 `App.jsx`에 모든 상태와 핸들러가 집중되어 파일이 비대해지는 문제가 있었습니다. `React Context`도 고려했으나 `Provide`r 설정이 필요하고 전체 리렌더링이 발생할 수 있습니다. `Zustand`는 선택적 구독이 가능하고 상태 로직을 컴포넌트 외부로 분리할 수 있어 선택했습니다.

### 상태 분류 기준 
2개 이상의 컴포넌트에서 공유되는 상태는 `Zustand`로 관리하고, 해당 컴포넌트에서만 사용되는 상태는 `useState`로 유지했습니다.
예를 들어 `isLoggedIn`, `summaryStatus`, `isModalOpen`은 여러 컴포넌트에서 필요하므로 전역으로 이동했고, `ImageAnalysisPage`의 `errorMessage`나 `HistoryPage`의 `histories`는 해당 페이지에서만 사용되므로 로컬로 유지했습니다.

### 스토어 구조 설계
도메인별로 3개의 독립적인 스토어로 분리했습니다. `useAuthStore`는 인증, `useModalStore`는 삭제 모달UI, `useResultStore`는 요약 및 분석 상태를 담당합니다.