### PR TITLE
refactor: UUID에서 JWT 게스트 토큰 전환

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,15 +14,15 @@ const App = () => {
   useEffect(() => {
     let isMounted = true;
 
-    chrome.storage.local.get("token", (result) => {
+    chrome.storage.local.get("userToken", (result) => {
       if (isMounted) {
-        setIsLoggedIn(Boolean(result.token));
+        setIsLoggedIn(Boolean(result.userToken));
       }
     });
 
     const handleStorageChange = (changes) => {
-      if (changes.token && isMounted) {
-        setIsLoggedIn(Boolean(changes.token.newValue));
+      if (changes.userToken && isMounted) {
+        setIsLoggedIn(Boolean(changes.userToken.newValue));
       }
 
       if (changes.rateLimitExceeded && changes.rateLimitExceeded.newValue === true && isMounted) {

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -32,6 +32,11 @@ const api = ky.create({
     ],
     afterResponse: [
       async (request, options, response) => {
+        const rateLimitRemaining = response.headers.get("RateLimit-Remaining");
+        if (rateLimitRemaining) {
+          await chrome.storage.local.set({ remainingCount: rateLimitRemaining });
+        }
+
         if (response.status === 429) {
           await chrome.storage.local.set({ rateLimitExceeded: true });
         }

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,15 +1,19 @@
 import ky from "ky";
 
-const getOrCreateGuestId = async () => {
-  const result = await chrome.storage.local.get("guestId");
+const fetchGuestToken = async () => {
+  const response = await api.post("auth/guest").json();
+  const token = response.data.token;
+  await chrome.storage.local.set({ guestToken: token });
+  return token;
+};
 
-  if (result.guestId) {
-    return result.guestId;
-  }
+const getAuthToken = async () => {
+  const { token, guestToken } = await chrome.storage.local.get(["token", "guestToken"]);
 
-  const guestId = crypto.randomUUID();
-  await chrome.storage.local.set({ guestId });
-  return guestId;
+  if (token) return token;
+  if (guestToken) return guestToken;
+
+  return await fetchGuestToken();
 };
 
 const api = ky.create({
@@ -18,19 +22,12 @@ const api = ky.create({
   hooks: {
     beforeRequest: [
       async (request) => {
-        try {
-          const result = await chrome.storage.local.get("token");
-          const token = result.token;
-
-          if (token) {
-            request.headers.set("Authorization", `Bearer ${token}`);
-          } else {
-            const guestId = await getOrCreateGuestId();
-            request.headers.set("Guest-Id", guestId);
-          }
-        } catch (error) {
-          console.error("헤더 설정 실패:", error);
+        if (request.url.includes("/auth/guest")) {
+          return;
         }
+
+        const token = await getAuthToken();
+        request.headers.set("Authorization", `Bearer ${token}`);
       },
     ],
     afterResponse: [
@@ -38,9 +35,20 @@ const api = ky.create({
         if (response.status === 429) {
           await chrome.storage.local.set({ rateLimitExceeded: true });
         }
+
+        if (response.status === 401) {
+          const newToken = await fetchGuestToken();
+          return ky(request, {
+            ...options,
+            headers: {
+              ...options.headers,
+              Authorization: `Bearer ${newToken}`,
+            },
+          });
+        }
       },
     ],
   },
 });
 
-export { api };
+export { api, fetchGuestToken, getAuthToken };

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,21 +1,5 @@
 import ky from "ky";
 
-const fetchGuestToken = async () => {
-  const response = await api.post("auth/guest").json();
-  const token = response.data.token;
-  await chrome.storage.local.set({ guestToken: token });
-  return token;
-};
-
-const getAuthToken = async () => {
-  const { userToken, guestToken } = await chrome.storage.local.get(["userToken", "guestToken"]);
-
-  if (userToken) return userToken;
-  if (guestToken) return guestToken;
-
-  return await fetchGuestToken();
-};
-
 const api = ky.create({
   prefixUrl: import.meta.env.VITE_API_BASE_URL,
   timeout: 30000,
@@ -55,5 +39,21 @@ const api = ky.create({
     ],
   },
 });
+
+const fetchGuestToken = async () => {
+  const response = await api.post("auth/guest").json();
+  const token = response.data.token;
+  await chrome.storage.local.set({ guestToken: token });
+  return token;
+};
+
+const getAuthToken = async () => {
+  const { userToken, guestToken } = await chrome.storage.local.get(["userToken", "guestToken"]);
+
+  if (userToken) return userToken;
+  if (guestToken) return guestToken;
+
+  return await fetchGuestToken();
+};
 
 export { api, fetchGuestToken, getAuthToken };

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -25,10 +25,15 @@ const api = ky.create({
           await chrome.storage.local.set({ rateLimitExceeded: true });
         }
 
-        if (response.status === 401) {
+        if (response.status === 401 && options._retried) {
+          return response;
+        }
+
+        if (response.status === 401 && !options._retried) {
           const newToken = await fetchGuestToken();
           return ky(request, {
             ...options,
+            _retried: true,
             headers: {
               ...options.headers,
               Authorization: `Bearer ${newToken}`,

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -8,9 +8,9 @@ const fetchGuestToken = async () => {
 };
 
 const getAuthToken = async () => {
-  const { token, guestToken } = await chrome.storage.local.get(["token", "guestToken"]);
+  const { userToken, guestToken } = await chrome.storage.local.get(["userToken", "guestToken"]);
 
-  if (token) return token;
+  if (userToken) return userToken;
   if (guestToken) return guestToken;
 
   return await fetchGuestToken();

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -1,7 +1,16 @@
-import { api } from "../api/client.js";
+import { api, fetchGuestToken } from "../api/client.js";
 
 const sidePanelConfig = { openPanelOnActionClick: true };
 const focusedImages = new Map();
+
+const isTokenExpired = (token) => {
+  try {
+    const payload = JSON.parse(atob(token.split(".")[1]));
+    return payload.exp * 1000 < Date.now();
+  } catch {
+    return true;
+  }
+};
 
 const handleSummarizeMessage = async (sendResponse) => {
   try {
@@ -71,6 +80,7 @@ const handleAnalyzeImage = async (payload, sendResponse) => {
     sendResponse({ success: false, error: error.message });
   }
 };
+
 const handleMessage = (message, sender, sendResponse) => {
   if (message.type === "IMAGE_FOCUSED") {
     focusedImages.set(sender.tab.id, {
@@ -117,6 +127,7 @@ const handleMessage = (message, sender, sendResponse) => {
     return true;
   }
 };
+
 const handleAnalyzeImageCommand = async (tab) => {
   const focusedImage = focusedImages.get(tab.id);
 
@@ -135,7 +146,7 @@ const handleAnalyzeImageCommand = async (tab) => {
   await chrome.storage.local.set({ pendingImageAnalysis: focusedImage });
 };
 
-const init = () => {
+const init = async () => {
   chrome.sidePanel.setPanelBehavior(sidePanelConfig).catch((error) => console.error(error));
   chrome.runtime.onMessage.addListener(handleMessage);
 
@@ -144,6 +155,11 @@ const init = () => {
       handleAnalyzeImageCommand(tab);
     }
   });
+
+  const { guestToken } = await chrome.storage.local.get("guestToken");
+  if (!guestToken || isTokenExpired(guestToken)) {
+    fetchGuestToken().catch((err) => console.error("초기 게스트 토큰 발급 실패:", err));
+  }
 };
 
 init();

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from "react";
 import Button from "./Button";
 import { SUMMARY_STATUS, IMAGE_ANALYSIS_STATUS } from "../constants/index.js";
 import useAuthStore from "../stores/useAuthStore";
@@ -8,6 +9,23 @@ const Footer = ({ currentPath }) => {
   const { isLoggedIn } = useAuthStore();
   const { summaryStatus, analysisStatus } = useResultStore();
   const { openModal } = useModalStore();
+
+  const [remainingCount, setRemainingCount] = useState(null);
+
+  useEffect(() => {
+    chrome.storage.local.get("remainingCount", (res) => {
+      setRemainingCount(res.remainingCount);
+    });
+
+    const handleStorageChange = (changes) => {
+      if (changes.remainingCount) {
+        setRemainingCount(changes.remainingCount.newValue);
+      }
+    };
+
+    chrome.storage.onChanged.addListener(handleStorageChange);
+    return () => chrome.storage.onChanged.removeListener(handleStorageChange);
+  }, []);
 
   const isLoading = summaryStatus === SUMMARY_STATUS.LOADING;
   const isResult = summaryStatus === SUMMARY_STATUS.RESULT;
@@ -24,7 +42,13 @@ const Footer = ({ currentPath }) => {
   const isDeleteButtonVisible = !isLoading && isLoggedIn && hasResult;
 
   return (
-    <footer className="flex justify-end gap-x-2">
+    <footer className="relative flex justify-end gap-x-2">
+      {isLoggedIn && remainingCount !== null && (
+        <div className="absolute left-0 top-1/2 -translate-y-1/2 text-base text-sl-black ml-1">
+          남은 횟수: {remainingCount}
+        </div>
+      )}
+
       {isSaveButtonVisible && (
         <Button bgColor="bg-sl-white" borderColor="border-sl-blue">
           저장

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -23,7 +23,7 @@ const Header = ({ currentPath }) => {
   };
 
   const handleLogoutClick = () => {
-    chrome.storage.local.remove("token");
+    chrome.storage.local.remove("userToken");
   };
 
   const handleSettingsClick = () => {

--- a/src/tabs/Login.jsx
+++ b/src/tabs/Login.jsx
@@ -12,7 +12,7 @@ const Login = () => {
         if (!isMounted) return;
 
         if (session) {
-          chrome.storage.local.set({ token: session.access_token }, () => {
+          chrome.storage.local.set({ userToken: session.access_token }, () => {
             chrome.tabs.getCurrent((tab) => {
               if (tab && tab.id) chrome.tabs.remove(tab.id);
             });


### PR DESCRIPTION
## 변경 내용

> #31 

- [x] JWT 게스트 토큰 발급 및 관리 로직 구현 
- [x] API 요청 헤더 Authorization: Bearer 방식으로 변경
- [x] Rate Limit 잔여 횟수 표시 UI 구현
- [x] 스토리지 키 리팩토링: token -> userToken (명확한 구분을 위해)

## 기타 참고 사항
### 1. JWT Guest Token 도입
- 인증 방식 변경: 기존 `Guest-Id` 커스텀 헤더 방식을 폐기하고, 표준 `Authorization: Bearer <token>` 방식으로 전환했습니다.
- 토큰 관리 자동화:
  - 익스텐션 실행(`background.init`) 시 토큰 만료 여부를 체크하고 필요 시 자동 재발급합니다.
  - API 호출 중 `401 Unauthorized` 발생 시, 투명하게 토큰을 재발급받고 요청을 재시도(Retry)하는 로직을 추가했습니다.

### 2. Rate Limit UI 개선
- 실시간 잔여 횟수 표시:
  - `RateLimit-Remaining` 응답 헤더를 파싱하여 Footer 좌측 하단에 남은 사용 횟수를 실시간으로 업데이트합니다.

### 3. 코드 리팩토링 및 안정성 강화
- 네이밍 명확화: 변수명을 `token` → `userToken`으로 변경하여 `guestToken`과의 역할을 명확히 구분했습니다.
- UI 버그 수정: Footer에서 횟수가 `0`일 때 UI가 사라지는 문제를 방지하기 위해 엄격한 조건문(`!== null`)을 적용했습니다.
- 메모리 누수 방지: `useEffect` 내에서 스토리지 리스너가 올바르게 해제(Cleanup)되도록 수정했습니다.

### 4. Rate Limit UI 표시 시점 (의도된 동작)
로그인 직후 Footer의 "남은 횟수" 표시 여부는 이전 사용 기록(스토리지) 유무에 따라 다르게 동작하며, 이는 버그가 아닙니다.

1. 기존 사용자 (재로그인): 스토리지에 이전 `remainingCount` 데이터가 남아있으므로 로그인 즉시 UI가 표시됩니다.
2. 신규 사용자 (첫 로그인): 스토리지에 데이터가 없으므로(`null`), 초기에는 UI가 보이지 않습니다. 이후 첫 API 호출(요약/분석) 완료 시점에 서버 응답을 받아 UI가 나타납니다.

### 5. 추후 구현 과제
- IP 기반 Rate Limit 도입: 현재 브라우저 스토리지 기반의 제한은 사용자가 토큰을 삭제하여 우회할 수 있는 한계가 있습니다. 이를 보완하기 위해 백엔드에서 IP 주소를 기반으로 한 더 강력한 제어 로직 도입이 필요합니다.