### PR TITLE
refactor: 접근성 개선

### DIFF
--- a/src/settings/pages/GeneralPage.jsx
+++ b/src/settings/pages/GeneralPage.jsx
@@ -67,8 +67,9 @@ const GeneralPage = () => {
       >
         저장
       </button>
-
-      {isSaved && <p className="mt-4 text-sl-gray-dark text-base">설정이 저장되었습니다.</p>}
+      <p role="status" className={`text-sl-gray-dark text-base ${isSaved ? "mt-4" : ""}`}>
+        {isSaved && "설정이 저장되었습니다."}
+      </p>
     </TabLayout>
   );
 };

--- a/src/shared/components/ErrorMessage.jsx
+++ b/src/shared/components/ErrorMessage.jsx
@@ -2,7 +2,7 @@ const ErrorMessage = ({ message, className = "" }) => {
   if (!message) return null;
 
   return (
-    <p role="alert" className={`text-sl-red text-lg ${className}`}>
+    <p role="alert" tabIndex={0} className={`text-sl-red text-lg ${className}`}>
       {message}
     </p>
   );

--- a/src/shared/components/NoData.jsx
+++ b/src/shared/components/NoData.jsx
@@ -1,7 +1,9 @@
 const NoData = ({ message }) => {
   return (
     <div className="flex justify-center items-center w-full h-full" role="status">
-      <p className="text-sl-gray-dark text-lg">{message}</p>
+      <p tabIndex={0} className="text-sl-gray-dark text-lg">
+        {message}
+      </p>
     </div>
   );
 };

--- a/src/shared/hooks/useFocusTrap.js
+++ b/src/shared/hooks/useFocusTrap.js
@@ -1,0 +1,51 @@
+import { useCallback } from "react";
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(", ");
+
+const getFocusableElements = (container) => {
+  return Array.from(container.querySelectorAll(FOCUSABLE_SELECTOR)).filter(
+    (element) => element.offsetParent !== null && !element.hasAttribute("disabled"),
+  );
+};
+
+const useFocusTrap = (containerRef) => {
+  return useCallback(
+    (event) => {
+      if (event.key !== "Tab") return;
+
+      const container = containerRef.current;
+
+      if (!container) return;
+
+      const focusable = getFocusableElements(container);
+
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const isFirst = document.activeElement === first;
+      const isLast = document.activeElement === last;
+
+      if (event.shiftKey && isFirst) {
+        event.preventDefault();
+        last.focus();
+        return;
+      }
+
+      if (!event.shiftKey && isLast) {
+        event.preventDefault();
+        first.focus();
+      }
+    },
+    [containerRef],
+  );
+};
+
+export default useFocusTrap;

--- a/src/sidepanel/App.jsx
+++ b/src/sidepanel/App.jsx
@@ -1,10 +1,12 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { Outlet, useLocation, useNavigate } from "react-router";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 import DeleteModal from "./components/DeleteModal";
 import useAuthStore from "../shared/stores/useAuthStore";
 import useSummaryStore from "../shared/stores/useSummaryStore";
+import useModalStore from "../shared/stores/useModalStore";
+import useFocusTrap from "../shared/hooks/useFocusTrap";
 import { fetchRateLimit } from "../shared/api/client";
 
 const App = () => {
@@ -12,6 +14,21 @@ const App = () => {
   const navigate = useNavigate();
   const { setIsLoggedIn } = useAuthStore();
   const { clearSummaryError } = useSummaryStore();
+  const { isModalOpen } = useModalStore();
+  const panelRef = useRef(null);
+  const prevModalOpenRef = useRef(false);
+  const handleKeyDown = useFocusTrap(panelRef);
+
+  useEffect(() => {
+    panelRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    if (prevModalOpenRef.current && !isModalOpen) {
+      panelRef.current?.focus();
+    }
+    prevModalOpenRef.current = isModalOpen;
+  }, [isModalOpen]);
 
   useEffect(() => {
     let isMounted = true;
@@ -61,14 +78,21 @@ const App = () => {
   }, []);
 
   return (
-    <div className="flex flex-col h-screen gap-5 p-5">
-      <Header currentPath={location.pathname} />
-      <main className="flex flex-col items-center gap-2 w-full h-full p-3 border border-sl-blue rounded-xl overflow-y-auto">
-        <Outlet />
-      </main>
-      <Footer currentPath={location.pathname} />
+    <>
+      <div
+        ref={panelRef}
+        tabIndex={-1}
+        onKeyDown={handleKeyDown}
+        className="flex flex-col h-screen gap-5 p-5 focus-visible:ring-2 focus-visible:ring-sl-blue outline-none"
+      >
+        <Header currentPath={location.pathname} />
+        <main className="flex flex-col items-center gap-2 w-full h-full p-3 border border-sl-blue rounded-xl overflow-y-auto">
+          <Outlet />
+        </main>
+        <Footer currentPath={location.pathname} />
+      </div>
       <DeleteModal />
-    </div>
+    </>
   );
 };
 

--- a/src/sidepanel/components/DeleteModal.jsx
+++ b/src/sidepanel/components/DeleteModal.jsx
@@ -1,10 +1,11 @@
-import { useState } from "react";
+import { useState, useRef, useCallback } from "react";
 import { useLocation, useNavigate, matchPath } from "react-router";
 import Button from "../../shared/components/Button";
 import ErrorMessage from "../../shared/components/ErrorMessage";
 import useModalStore from "../../shared/stores/useModalStore";
 import useSummaryStore from "../../shared/stores/useSummaryStore";
 import useAnalysisStore from "../../shared/stores/useAnalysisStore";
+import useFocusTrap from "../../shared/hooks/useFocusTrap";
 
 const DeleteModal = () => {
   const location = useLocation();
@@ -14,6 +15,14 @@ const DeleteModal = () => {
   const { summaryData, resetSummary } = useSummaryStore();
   const { analysisData, resetAnalysis } = useAnalysisStore();
   const [deleteError, setDeleteError] = useState(null);
+
+  const modalRef = useRef(null);
+  const handleTrapKeyDown = useFocusTrap(modalRef);
+
+  const setModalRef = useCallback((node) => {
+    modalRef.current = node;
+    if (node) node.focus();
+  }, []);
 
   if (!isModalOpen) return null;
 
@@ -74,12 +83,22 @@ const DeleteModal = () => {
   };
 
   return (
-    <div className="fixed inset-0 z-10 flex items-end justify-center">
+    <div
+      ref={setModalRef}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="modal-title"
+      tabIndex={-1}
+      onKeyDown={handleTrapKeyDown}
+      className="fixed inset-0 z-10 flex items-end justify-center outline-none"
+    >
       <div className="absolute inset-0 bg-sl-black/85"></div>
       <div className="relative w-full m-3 p-6 bg-sl-white border-3 border-sl-blue rounded-2xl shadow-2xl">
-        <h2 className="mb-2 text-xl font-bold text-sl-black">기록 삭제</h2>
-        <p className="mb-6 text-base font-semibold text-sl-black">
-          이 채팅을 삭제하시겠습니까? 이 작업은 취소할 수 없습니다.
+        <h2 id="modal-title" className="mb-2 text-xl font-bold text-sl-black">
+          기록 삭제
+        </h2>
+        <p tabIndex={0} className="mb-6 text-base font-semibold text-sl-black">
+          이 채팅을 삭제하시겠습니까?
         </p>
         <ErrorMessage message={deleteError} className="mb-4" />
         <div className="flex justify-end gap-3">

--- a/src/sidepanel/components/Footer.jsx
+++ b/src/sidepanel/components/Footer.jsx
@@ -49,7 +49,10 @@ const Footer = ({ currentPath }) => {
   return (
     <footer className="relative flex justify-end gap-x-2">
       {remainingCount !== null && (
-        <div className="absolute left-0 top-1/2 -translate-y-1/2 text-base text-sl-black ml-1">
+        <div
+          tabIndex={0}
+          className="absolute left-0 top-1/2 -translate-y-1/2 text-base text-sl-black ml-1"
+        >
           남은 횟수: {remainingCount}
         </div>
       )}

--- a/src/sidepanel/components/Pagination.jsx
+++ b/src/sidepanel/components/Pagination.jsx
@@ -16,6 +16,7 @@ const Pagination = ({ currentPage, totalPages, onPageChange }) => {
         <button
           type="button"
           onClick={handlePrevGroup}
+          aria-label="이전 페이지 목록"
           className="px-2 py-1 text-sl-blue cursor-pointer"
         >
           &lt;
@@ -26,6 +27,7 @@ const Pagination = ({ currentPage, totalPages, onPageChange }) => {
           key={page}
           type="button"
           onClick={() => onPageChange(page)}
+          aria-current={currentPage === page ? "page" : undefined}
           className={`px-2 py-1 cursor-pointer ${
             currentPage === page ? "font-bold text-sl-blue" : "text-sl-gray-dark"
           }`}
@@ -37,6 +39,7 @@ const Pagination = ({ currentPage, totalPages, onPageChange }) => {
         <button
           type="button"
           onClick={handleNextGroup}
+          aria-label="다음 페이지 목록"
           className="px-2 py-1 text-sl-blue cursor-pointer"
         >
           &gt;

--- a/src/sidepanel/pages/HistoryDetailPage.jsx
+++ b/src/sidepanel/pages/HistoryDetailPage.jsx
@@ -1,9 +1,14 @@
+import { useCallback } from "react";
 import { useLocation, Link } from "react-router";
 import { formatDate } from "../../shared/utils/formatDate";
 
 const HistoryDetailPage = () => {
   const location = useLocation();
   const { history } = location.state || {};
+
+  const detailRef = useCallback((node) => {
+    if (node) node.focus();
+  }, []);
 
   if (!history) {
     return (
@@ -18,10 +23,18 @@ const HistoryDetailPage = () => {
 
   return (
     <div className="flex flex-col w-full h-full">
-      <div className="flex flex-col flex-1 gap-4 overflow-y-auto">
+      <div
+        ref={detailRef}
+        tabIndex={0}
+        className="flex flex-col flex-1 gap-4 overflow-y-auto focus-visible:ring-2 focus-visible:ring-sl-blue outline-none"
+      >
         <h1 className="text-3xl">{history.contents.title}</h1>
-        <p className="text-sl-gray-dark text-sm">요약 날짜: {formatDate(history.createdAt)}</p>
-        <p className="text-lg">{history.contents.summary}</p>
+        <p tabIndex={0} className="text-sl-gray-dark text-sm">
+          요약 날짜: {formatDate(history.createdAt)}
+        </p>
+        <p tabIndex={0} className="text-lg">
+          {history.contents.summary}
+        </p>
       </div>
       <Link
         to="/history"

--- a/src/sidepanel/pages/HistoryPage.jsx
+++ b/src/sidepanel/pages/HistoryPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Link } from "react-router";
 import NoData from "../../shared/components/NoData";
 import LoadingSpinner from "../../shared/components/LoadingSpinner";
@@ -13,6 +13,10 @@ const HistoryPage = () => {
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
   const [fetchError, setFetchError] = useState(null);
+
+  const firstItemRef = useCallback((node) => {
+    if (node) node.focus();
+  }, []);
 
   useEffect(() => {
     let isMounted = true;
@@ -69,9 +73,10 @@ const HistoryPage = () => {
   return (
     <div className="flex flex-col w-full h-full">
       <ul className="flex flex-col w-full gap-3 flex-1">
-        {histories.map((history) => (
+        {histories.map((history, index) => (
           <li key={history.id}>
             <Link
+              ref={index === 0 ? firstItemRef : undefined}
               to={`/history/${history.id}`}
               state={{ history }}
               className="block w-full h-10 px-4 bg-sl-blue rounded-2xl text-base text-sl-white truncate leading-10 text-center"

--- a/src/sidepanel/pages/ImageAnalysisPage.jsx
+++ b/src/sidepanel/pages/ImageAnalysisPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import LoadingSpinner from "../../shared/components/LoadingSpinner";
 import ErrorMessage from "../../shared/components/ErrorMessage";
 import { IMAGE_ANALYSIS_STATUS } from "../../shared/constants/index";
@@ -7,6 +7,10 @@ import useAnalysisStore from "../../shared/stores/useAnalysisStore";
 const ImageAnalysisPage = () => {
   const [errorMessage, setErrorMessage] = useState(null);
   const { analysisStatus, analysisData, setAnalysisResult, setAnalysisError } = useAnalysisStore();
+
+  const resultRef = useCallback((node) => {
+    if (node) node.focus();
+  }, []);
 
   useEffect(() => {
     let isActive = true;
@@ -60,12 +64,21 @@ const ImageAnalysisPage = () => {
 
   return (
     <div className="flex flex-col items-center justify-center w-full h-full">
+      <div aria-live="polite" className="sr-only">
+        {analysisStatus === IMAGE_ANALYSIS_STATUS.LOADING &&
+          "이미지를 분석중입니다. 잠시만 기다려주세요."}
+        {analysisStatus === IMAGE_ANALYSIS_STATUS.ERROR && errorMessage}
+      </div>
       {analysisStatus === IMAGE_ANALYSIS_STATUS.LOADING && (
         <LoadingSpinner message="이미지를 분석중입니다..." />
       )}
 
       {analysisStatus === IMAGE_ANALYSIS_STATUS.RESULT && analysisData && (
-        <div className="flex flex-col gap-4">
+        <div
+          ref={resultRef}
+          tabIndex={0}
+          className="flex flex-col gap-4 focus-visible:ring-2 focus-visible:ring-sl-blue outline-none"
+        >
           <h1 className="text-3xl">{analysisData.title}</h1>
           <p className="text-2xl">{analysisData.summary}</p>
         </div>

--- a/src/sidepanel/pages/SummaryPage.jsx
+++ b/src/sidepanel/pages/SummaryPage.jsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import LoadingSpinner from "../../shared/components/LoadingSpinner";
 import ErrorMessage from "../../shared/components/ErrorMessage";
 import { SUMMARY_STATUS } from "../../shared/constants/index";
@@ -13,6 +14,10 @@ const SummaryPage = () => {
     setSummaryError,
   } = useSummaryStore();
 
+  const resultRef = useCallback((node) => {
+    if (node) node.focus();
+  }, []);
+
   const handleSummaryClick = async () => {
     setSummaryLoading();
 
@@ -27,6 +32,10 @@ const SummaryPage = () => {
 
   return (
     <div className="flex flex-col items-center justify-center w-full h-full">
+      <div aria-live="polite" className="sr-only">
+        {summaryStatus === SUMMARY_STATUS.LOADING && "페이지를 요약중입니다. 잠시만 기다려주세요."}
+        {summaryStatus === SUMMARY_STATUS.ERROR && summaryError}
+      </div>
       {(summaryStatus === SUMMARY_STATUS.DEFAULT || summaryStatus === SUMMARY_STATUS.ERROR) && (
         <>
           <button
@@ -34,11 +43,7 @@ const SummaryPage = () => {
             onClick={handleSummaryClick}
             className="flex items-center justify-center gap-2 w-full h-[30px] bg-sl-blue border rounded-2xl font-medium text-white cursor-pointer"
           >
-            <img
-              src="/images/icons/spreadlove-summary-16.svg"
-              alt="요약 아이콘"
-              aria-hidden="true"
-            />
+            <img src="/images/icons/spreadlove-summary-16.svg" alt="" aria-hidden="true" />
             <span>이 페이지 요약하기</span>
           </button>
           {summaryStatus === SUMMARY_STATUS.ERROR && (
@@ -50,7 +55,11 @@ const SummaryPage = () => {
         <LoadingSpinner message={"페이지를 요약중입니다..."} />
       )}
       {summaryStatus === SUMMARY_STATUS.RESULT && summaryData && (
-        <div className="flex flex-col gap-4">
+        <div
+          ref={resultRef}
+          tabIndex={0}
+          className="flex flex-col gap-4 focus-visible:ring-2 focus-visible:ring-sl-blue outline-none"
+        >
           <h1 className="text-3xl">{summaryData.title}</h1>
           <p className="text-2xl">{summaryData.summary}</p>
         </div>


### PR DESCRIPTION
## 변경 내용

> #43

- [x] 삭제 모달에 WAI-ARIA 다이얼로그 패턴 적용 (`role="dialog"`, `aria-modal`, `aria-labelledby`, 포커스 트랩)
- [x] 로딩/에러 상태를 스크린 리더가 자동으로 안내하도록 `aria-live` 적용
- [x] 요약/이미지 분석 결과 표시 시 결과 영역으로 자동 포커스 이동
- [x] 기록 목록/상세 페이지 진입 시 콘텐츠로 자동 포커스 이동
- [x] 설정 저장 완료 메시지를 스크린 리더가 읽도록 `role="status"` 적용
- [x] 페이지네이션 이전/다음 버튼에 `aria-label`, 현재 페이지에 `aria-current` 적용
- [x] 결과 영역, 남은 횟수, 에러 메시지, NoData에 `tabIndex={0}` 적용

## 기타참고 사항

VoiceOver를 켜고 실제 사용자 흐름을 생각하고 직접 조작하여 문제를 파악하고 개선했습니다.

### 참고 레퍼런스
[WCAG](https://www.w3.org/WAI/standards-guidelines/wcag/)

### VoiceOver 테스트[mac 기준] 방법
#### [요약하기]
1. 먼저 설정 -> VoiceOver를 킨다.
2. 브라우저에 접속한다. 
3. 웹 익스텐션을 킨다.
    - [브라우저 모드] (패널 열림 시 자동 탐색)
      1.사이드 패널 열기 → 남은 횟수 → 로고 → 로그인 → 설정 → 요약하기 → 닫기 순서로 읽히는지 확인
      2.요약하기에서 Enter → "웹 페이지를 요약중입니다" 안내 확인
      3.결과 표시 후 → 결과 영역이 자동으로 읽히는지 확인

#### [분석하기]
1. 익스텐션 단축키 설정 후
2. VoiceOver를 킵니다.
3. 브라우저에 접속하여 분석이 필요한 이미지에 포커스를 둔다.
4. 단축키를 누른다.
5. 사이드 패널이 열림 -> "이미지를 분석중입니다." 안내 확인 
6. 결과 표시후 -> 결과 영역이 자동으로 읽히는지 확인.


#### [공통]
- [포커스 모드]   
1.Tab으로 이동 → tabIndex가 있는 요소들(남은 횟수, 결과 영역, 에러 메시지 등)에 접근 가능한지 확인
2.기록 페이지 이동 → 첫 번째 항목으로 포커스 자동 이동 확인
3.기록 상세 페이지 → 콘텐츠 영역으로 포커스 자동 이동 확인
4.삭제 버튼 클릭 → 모달 내부에서만 Tab 순환 확인 (포커스 트랩)
5.모달 닫기 → 원래 위치로 포커스 복귀 확인

---

### 포커스 트랩 적용

사이드 패널에서 Tab을 반복하면 포커스가 사이드 패널을 빠져나가는 문제가 있었고, 삭제 모달에서도 모달 뒤의 버튼으로 포커스가 이동하는 문제가 있었습니다. useFocusTrap 커스텀 훅을 만들어 패널과 모달 각각에 적용했고, 모달이 닫히면 원래 위치로 포커스가 복귀하도록 처리했습니다.

### 상태 변화 안내

로딩, 에러, 결과 같은 화면 변화가 일어나도 스크린 리더가 이를 감지하지 못하는 문제가 있었습니다. 각 페이지에 sr-only aria-live 영역을 배치하여 상태 변화를 자동으로 안내하도록 했습니다. 처음에 <main>에 전역으로 aria-live를 적용했으나 라우트 전환 시 페이지 전체를 읽어버려서, 페이지별로 분리하는 방식으로 변경했습니다.

### 남은 횟수, 에러 메시지, 콘텐츠 내용등에 tabIndex 추가

VoiceOver의 가상 커서가 제한적으로 동작하여, tabIndex가 없는 텍스트 콘텐츠에 다시 접근할 수 없어 사용자가 정보를 얻는데 불편함을 느낄 것 같다고 생각했습니다.
그래서 결과 영역, 남은 횟수, 에러 메시지 등 비대화형 요소에 tabIndex={0}을 적용하여 Tab으로 접근할 수 있도록 했습니다.

