### PR TITLE
fix: OAuth 로그인 오류 수정

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -39,5 +39,11 @@
   ],
   "permissions": ["sidePanel", "storage", "activeTab", "tabs"],
   "host_permissions": ["https://api.spreadloved.com/*"],
-  "options_page": "src/settings/index.html"
+  "options_page": "src/settings/index.html",
+  "web_accessible_resources": [
+    {
+      "resources": ["src/login/index.html"],
+      "matches": ["https://*.google.com/*"]
+    }
+  ]
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,6 +6,13 @@ import manifest from "./manifest.json";
 
 export default defineConfig({
   plugins: [react(), tailwindcss(), crx({ manifest })],
+  build: {
+    rollupOptions: {
+      input: {
+        login: "src/login/index.html",
+      },
+    },
+  },
   server: {
     port: 5173,
     hmr: {


### PR DESCRIPTION
## 변경 내용

> #47

- [x] 프로덕션 빌드 환경에서 OAuth 로그인이 차단되는 버그 수정
- [x] OAuth 로그인 페이지를 `web_accessible_resources`에 추가
- [x] Vite 빌드 설정에 로그인 페이지 엔트리 추가 

## 기타 참고 사항

### OAuth 버그 원인
개발 환경에서는 `src/login/index.html`에 직접 접근이 가능하지만,
빌드 후에는 크롬 익스텐션의 보안 정책에 의해 내부 HTML 파일 접근이 차단되었습니다.
`web_accessible_resources`에 로그인 페이지를 등록하고,
Vite의 `rollupOptions.input`에 엔트리로 추가하여 빌드 결과물에 포함되도록 수정했습니다.